### PR TITLE
Support multiple builds in one repo

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ on:
       clean:
         description: Remove deleted files from the build
         required: false
-        type: bool
+        type: boolean
         default: true
       manifest_filename:
         description: Filename of the manifest to write.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -70,8 +70,9 @@ jobs:
 
       - name: Create single manifest.json
         run: |
-          name=$(echo "${{ inputs.name }}" | sed 's/ /\ /g')
-          jq -s '{"name": "${{ inputs.name }}", "version": "${{ needs.build.outputs.esphome-version }}", "home_assistant_domain": "esphome", "new_install_skip_erase": false, "builds":.}' output/${name}-*/manifest.json > output/${{ inputs.manifest_filename }}
+          name=$(echo "${{ inputs.name }}" | sed 's/ /\\ /g')
+          echo $name
+          jq -s '{"name": "${{ inputs.name }}", "version": "${{ needs.build.outputs.esphome-version }}", "home_assistant_domain": "esphome", "new_install_skip_erase": false, "builds":.}' output/$name-*/manifest.json > output/${{ inputs.manifest_filename }}
 
       - run: cp -R static/* output
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,6 +12,16 @@ on:
         required: false
         type: string
         default: ESPHome
+      clean:
+        description: Remove deleted files from the build
+        required: false
+        type: bool
+        default: true
+      manifest_filename:
+        description: Filename of the manifest to write.
+        required: false
+        type: string
+        default: manifest.json
     secrets:
       GH_TOKEN:
         required: true
@@ -60,7 +70,7 @@ jobs:
 
       - name: Create single manifest.json
         run: |
-          jq -s '{"name": "${{ inputs.name }}", "version": "${{ needs.build.outputs.esphome-version }}", "home_assistant_domain": "esphome", "new_install_skip_erase": false, "builds":.}' output/*/manifest.json > output/manifest.json
+          jq -s '{"name": "${{ inputs.name }}", "version": "${{ needs.build.outputs.esphome-version }}", "home_assistant_domain": "esphome", "new_install_skip_erase": false, "builds":.}' output/*/manifest.json > output/${{ inputs.manifest_filename }}
 
       - run: cp -R static/* output
 
@@ -69,5 +79,6 @@ jobs:
         with:
           branch: gh-pages
           folder: output
+          clean: ${{ inputs.clean }}
         secrets:
           token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -69,7 +69,13 @@ jobs:
         run: |
           name=$(echo "${{ inputs.name }}" | sed 's/ /\\ /g')
           echo $name
-          jq -s '{"name": "${{ inputs.name }}", "version": "${{ needs.build.outputs.esphome-version }}", "home_assistant_domain": "esphome", "new_install_skip_erase": false, "builds":.}' output/$name-*/manifest.json > output/${{ inputs.manifest_filename }}
+          jq -s '{\
+              "name": "${{ inputs.name }}", \
+              "version": "${{ needs.build.outputs.esphome-version }}", \
+              "home_assistant_domain": "esphome", \
+              "new_install_skip_erase": false, \
+              "builds":.\
+            }' output/"$name"-*/manifest.json > output/${{ inputs.manifest_filename }}
 
       - run: cp -R static/* output
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Create single manifest.json
         run: |
-          name=${{ inputs.name }}
+          name="${{ inputs.name }}"
           jq -s '{"name": "${{ inputs.name }}", "version": "${{ needs.build.outputs.esphome-version }}", "home_assistant_domain": "esphome", "new_install_skip_erase": false, "builds":.}' output/"$name"-*/manifest.json > output/${{ inputs.manifest_filename }}
 
       - run: cp -R static/* output

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -70,7 +70,8 @@ jobs:
 
       - name: Create single manifest.json
         run: |
-          jq -s '{"name": "${{ inputs.name }}", "version": "${{ needs.build.outputs.esphome-version }}", "home_assistant_domain": "esphome", "new_install_skip_erase": false, "builds":.}' "output/${{ inputs.name }}-*/manifest.json" > output/${{ inputs.manifest_filename }}
+          name=$(echo "${{ inputs.name }}" | sed 's/ /\ /g')
+          jq -s '{"name": "${{ inputs.name }}", "version": "${{ needs.build.outputs.esphome-version }}", "home_assistant_domain": "esphome", "new_install_skip_erase": false, "builds":.}' output/${name}-*/manifest.json > output/${{ inputs.manifest_filename }}
 
       - run: cp -R static/* output
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -55,7 +55,7 @@ jobs:
           yaml_file: ${{ matrix.file }}
       - uses: actions/upload-artifact@v2.3.0
         with:
-          name: ${{ steps.esphome-build.outputs.name }}
+          name: ${{ inputs.name }}-${{ steps.esphome-build.outputs.name }}
           path: ${{ steps.esphome-build.outputs.name }}
 
   publish:
@@ -70,7 +70,7 @@ jobs:
 
       - name: Create single manifest.json
         run: |
-          jq -s '{"name": "${{ inputs.name }}", "version": "${{ needs.build.outputs.esphome-version }}", "home_assistant_domain": "esphome", "new_install_skip_erase": false, "builds":.}' output/*/manifest.json > output/${{ inputs.manifest_filename }}
+          jq -s '{"name": "${{ inputs.name }}", "version": "${{ needs.build.outputs.esphome-version }}", "home_assistant_domain": "esphome", "new_install_skip_erase": false, "builds":.}' output/${{ inputs.name }}-*/manifest.json > output/${{ inputs.manifest_filename }}
 
       - run: cp -R static/* output
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Create single manifest.json
         run: |
-          jq -s '{"name": "${{ inputs.name }}", "version": "${{ needs.build.outputs.esphome-version }}", "home_assistant_domain": "esphome", "new_install_skip_erase": false, "builds":.}' output/${{ inputs.name }}-*/manifest.json > output/${{ inputs.manifest_filename }}
+          jq -s '{"name": "${{ inputs.name }}", "version": "${{ needs.build.outputs.esphome-version }}", "home_assistant_domain": "esphome", "new_install_skip_erase": false, "builds":.}' "output/${{ inputs.name }}-*/manifest.json" > output/${{ inputs.manifest_filename }}
 
       - run: cp -R static/* output
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -67,15 +67,8 @@ jobs:
 
       - name: Create single manifest.json
         run: |
-          name=$(echo "${{ inputs.name }}" | sed 's/ /\\ /g')
-          echo $name
-          jq -s '{\
-              "name": "${{ inputs.name }}", \
-              "version": "${{ needs.build.outputs.esphome-version }}", \
-              "home_assistant_domain": "esphome", \
-              "new_install_skip_erase": false, \
-              "builds":.\
-            }' output/"$name"-*/manifest.json > output/${{ inputs.manifest_filename }}
+          name=${{ inputs.name }}
+          jq -s '{"name": "${{ inputs.name }}", "version": "${{ needs.build.outputs.esphome-version }}", "home_assistant_domain": "esphome", "new_install_skip_erase": false, "builds":.}' output/"$name"-*/manifest.json > output/${{ inputs.manifest_filename }}
 
       - run: cp -R static/* output
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -80,5 +80,4 @@ jobs:
           branch: gh-pages
           folder: output
           clean: ${{ inputs.clean }}
-        secrets:
           token: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
These changes allow multiple devices/projects in a single repo, like firmwares for multiple different devices in the same repo and a single website. 
It will generate a manifest for each "project" that you can use in the website pages.

For an example see https://github.com/jesserockz/sonoff-configs