### PR TITLE
Revert "Bump esphome/build-action from 1.5.2 to 1.5.3 (#40)"

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -50,7 +50,7 @@ jobs:
       esphome-version: ${{ steps.esphome-build.outputs.esphome-version }}
     steps:
       - uses: actions/checkout@v3.2.0
-      - uses: esphome/build-action@v1.5.3
+      - uses: esphome/build-action@v1.5.2
         id: esphome-build
         with:
           yaml_file: ${{ matrix.file }}


### PR DESCRIPTION
This reverts commit e3f327e50606328a901db4b597b6f1cad4b3a803.

The upstream tag for 1.5.3 hasn't been janked, causing the upgrades to roll out (while the feature has been reverted in <https://github.com/esphome/build-action/pull/13>

