### PR TITLE
Remove deprecated set-output

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -78,9 +78,7 @@ jobs:
         run: |
           jq -s '{"name": "${{ inputs.name }}", "version": "${{ needs.build.outputs.esphome-version }}", "home_assistant_domain": "esphome", "new_install_skip_erase": false, "builds":.}' output/*/manifest.json > output/${{ inputs.manifest_filename }}
 
-      - name: Move static website files (if they exist)
-        if: ${{ hashFiles('static/') != '' }}
-        run: cp -R static/* output
+      - run: cp -R static/* output
 
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@v4.6.1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,7 +37,7 @@ jobs:
       - id: files-array
         run: |
           files=$(echo "${{ inputs.files }}" | jq -Rcn 'inputs | . / ","')
-          echo ::set-output name=files::$files
+          echo files=$files >> $GITHUB_OUTPUT
 
   build:
     name: Build ESPHome binary for ${{ matrix.file }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,7 +37,7 @@ jobs:
       - id: files-array
         run: |
           files=$(echo "${{ inputs.files }}" | jq -Rcn 'inputs | . / ","')
-          echo files=$files >> $GITHUB_OUTPUT
+          echo "files=$files" >> $GITHUB_OUTPUT
 
   build:
     name: Build ESPHome binary for ${{ matrix.file }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -78,7 +78,9 @@ jobs:
         run: |
           jq -s '{"name": "${{ inputs.name }}", "version": "${{ needs.build.outputs.esphome-version }}", "home_assistant_domain": "esphome", "new_install_skip_erase": false, "builds":.}' output/*/manifest.json > output/${{ inputs.manifest_filename }}
 
-      - run: cp -R static/* output
+      - name: Move static website files (if they exist)
+        if: ${{ hashFiles('static/') != '' }}
+        run: cp -R static/* output
 
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@v4.6.1


### PR DESCRIPTION
`set-output` is deprecated in favor of the GITHUB_OUTPUT environment variable.

Fixes #59 