### PR TITLE
Split build and upload workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -116,8 +116,6 @@ jobs:
           path: files
           pattern: ${{ needs.prepare.outputs.artifact-prefix }}-*
 
-      - run: tree
-
       - name: Get artifact names
         id: artifacts
         run: |
@@ -126,7 +124,8 @@ jobs:
           echo "$artifacts" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
-      - uses: geekyeggo/delete-artifact@v5.0.0
+      - name: Delete prefixed artifacts
+        uses: geekyeggo/delete-artifact@v5.0.0
         with:
           name: ${{ steps.artifacts.outputs.artifacts }}
 
@@ -144,8 +143,6 @@ jobs:
           done
           popd
           jq -s '(.[0] | del(.builds)) + {"builds": (reduce .[].builds as $b ([]; . + $b))}' files/*/$version/manifest.json > output/$version/manifest.json
-
-      - run: tree output
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4.3.4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -122,7 +122,9 @@ jobs:
         id: artifacts
         run: |
           artifacts=$(ls --format=single-column files)
-          echo "artifacts=$artifacts" >> $GITHUB_OUTPUT
+          echo "artifacts<<EOF" >> $GITHUB_OUTPUT
+          echo "$artifacts" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
 
       - uses: geekyeggo/delete-artifact@v5.0.0
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -116,17 +116,17 @@ jobs:
           path: files
           pattern: ${{ needs.prepare.outputs.artifact-prefix }}-*
 
+      - run: tree
+
       - name: Get artifact names
         id: artifacts
         run: |
           artifacts=$(ls --format=single-column files)
-          echo artifacts="$artifacts" >> $GITHUB_OUTPUT
+          echo "artifacts=$artifacts" >> $GITHUB_OUTPUT
 
       - uses: geekyeggo/delete-artifact@v5.0.0
         with:
           name: ${{ steps.artifacts.outputs.artifacts }}
-
-      - run: tree
 
       - name: Combine all parts into a single manifest
         run: |
@@ -140,6 +140,8 @@ jobs:
           done
           popd
           jq -s '(.[0] | del(.builds)) + {"builds": (reduce .[].builds as $b ([]; . + $b))}' files/*/$version/manifest.json > output/$version/manifest.json
+
+      - run: tree output
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4.3.4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,6 +39,11 @@ on:
         required: false
         type: string
         default: ""
+      combined_name:
+        description: Combine all files into a single manifest under this name
+        required: false
+        type: string
+        default: ""
 
 jobs:
   prepare:
@@ -87,7 +92,7 @@ jobs:
         with:
           yaml-file: ${{ matrix.file }}
           version: ${{ inputs.esphome-version }}
-          complete-manifest: true
+          complete-manifest: ${{ inputs.combined_name == '' }}
           release-summary: ${{ inputs.release-summary }}
           release-url: ${{ inputs.release-url }}
       - name: Move files for versioning
@@ -97,7 +102,51 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v4.3.4
         with:
-          name: ${{ steps.esphome-build.outputs.original-name }}
+          name: ${{ inputs.combined_name != '' && steps.esphome-build.outputs.name || steps.esphome-build.outputs.original-name }}
+          path: output
+
+  combine:
+    name: Combine all parts into a single manifest
+    needs:
+      - prepare
+      - build
+    runs-on: ubuntu-latest
+    if: inputs.combined_name != ''
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4.1.8
+        with:
+          path: files
+
+      - name: Get artifact names
+        id: artifacts
+        run: |
+          artifacts=$(ls --format=single-column files)
+          echo artifacts="$artifacts" >> $GITHUB_OUTPUT
+
+      - uses: geekyeggo/delete-artifact@v5.0.0
+        with:
+          name: ${{ steps.artifacts.outputs.artifacts }}
+
+      - run: tree
+
+      - name: Combine all parts into a single manifest
+        run: |
+          version="${{ needs.prepare.outputs.version }}"
+          mkdir -p "output/$version"
+          pushd files
+          for device in *; do
+            pushd $device
+            cp * "../../output/$version/"
+            popd
+          done
+          popd
+          jq -s '(.[0] | del(.builds)) + {"builds": (reduce .[].builds as $b ([]; . + $b))}' files/*/$version/manifest.json > output/$version/manifest.json
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4.3.4
+        with:
+          name: ${{ inputs.combined_name }}
           path: output
 
   upload:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,7 +69,7 @@ jobs:
           echo artifact-prefix=$artifact_prefix >> $GITHUB_OUTPUT
 
   build:
-    name: Build ESPHome firmware for ${{ matrix.file }}
+    name: ${{ matrix.file }}
     needs: [prepare]
     runs-on: ubuntu-latest
     strategy:
@@ -89,7 +89,7 @@ jobs:
         with:
           yaml-file: ${{ matrix.file }}
           version: ${{ inputs.esphome-version }}
-          complete-manifest: ${{ inputs.combined-name == '' }}
+          complete-manifest: true
           release-summary: ${{ inputs.release-summary }}
           release-url: ${{ inputs.release-url }}
       - name: Move files for versioning
@@ -103,7 +103,7 @@ jobs:
           path: output
 
   combine:
-    name: Combine all parts into a single manifest
+    name: Combine manifests
     needs:
       - prepare
       - build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -137,7 +137,9 @@ jobs:
           pushd files
           for device in *; do
             pushd $device
+            pushd $version
             cp * "../../output/$version/"
+            popd
             popd
           done
           popd

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -138,7 +138,7 @@ jobs:
           for device in *; do
             pushd $device
             pushd $version
-            cp * "../../output/$version/"
+            cp * "../../../output/$version/"
             popd
             popd
           done

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,8 +65,8 @@ jobs:
       - name: Generated random artifact prefix
         id: artifact-name
         run: |
-          artifact_prefix=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1)
-          echo artifact-prefix=$artifact_name >> $GITHUB_OUTPUT
+          artifact_prefix=$(tr -dc A-Za-z0-9 </dev/urandom | head -c 16; echo)
+          echo artifact-prefix=$artifact_prefix >> $GITHUB_OUTPUT
 
   build:
     name: Build ESPHome firmware for ${{ matrix.file }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,4 @@
 name: Build
-# This workflow is only to be used within the ESPHome organisation on GitHub.
-# It is used to build and upload the binaries to Cloudflare R2 and only
-# specific repositories will be granted the secrets required to do so.
 
 on:
   workflow_call:
@@ -9,10 +6,6 @@ on:
       files:
         description: Newline separated list of files to build
         required: true
-        type: string
-      name:
-        description: Name of the firmware to publish
-        required: false
         type: string
       esphome-version:
         description: Version of ESPHome to build with
@@ -29,21 +22,21 @@ on:
         required: false
         type: string
         default: ""
-      upload:
-        description: Upload the firmware to Cloudflare R2
-        required: false
-        type: boolean
-        default: false
       release-version:
         description: Version of the release
         required: false
         type: string
         default: ""
-      combined_name:
+      combined-name:
         description: Combine all files into a single manifest under this name
         required: false
         type: string
         default: ""
+
+    outputs:
+      version:
+        description: Version of the firmware generated
+        value: ${{ jobs.prepare.outputs.version }}
 
 jobs:
   prepare:
@@ -52,6 +45,7 @@ jobs:
     outputs:
       files: ${{ steps.files-array.outputs.files }}
       version: ${{ steps.version.outputs.version }}
+      artifact-prefix: ${{ steps.artifact-name.outputs.artifact-prefix }}
     steps:
       - name: Split files input into JSON array
         id: files-array
@@ -63,13 +57,16 @@ jobs:
         run: |
           if [ -n "${{ inputs.release-version }}" ]; then
             version=${{ inputs.release-version }}
-          elif [ "${{ inputs.upload }}" == "true" ]; then
-            version=dev-$(date +'%Y%m%d-%H%M')
           else
-            version=dev
+            version=dev-$(date +'%Y%m%d-%H%M')
           fi
 
           echo version=$version >> $GITHUB_OUTPUT
+      - name: Generated random artifact prefix
+        id: artifact-name
+        run: |
+          artifact_prefix=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1)
+          echo artifact-prefix=$artifact_name >> $GITHUB_OUTPUT
 
   build:
     name: Build ESPHome firmware for ${{ matrix.file }}
@@ -92,7 +89,7 @@ jobs:
         with:
           yaml-file: ${{ matrix.file }}
           version: ${{ inputs.esphome-version }}
-          complete-manifest: ${{ inputs.combined_name == '' }}
+          complete-manifest: ${{ inputs.combined-name == '' }}
           release-summary: ${{ inputs.release-summary }}
           release-url: ${{ inputs.release-url }}
       - name: Move files for versioning
@@ -102,7 +99,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v4.3.4
         with:
-          name: ${{ inputs.combined_name != '' && steps.esphome-build.outputs.name || steps.esphome-build.outputs.original-name }}
+          name: ${{ inputs.combined-name != '' && format('{0}-{1}', needs.prepare.outputs.artifact-prefix, steps.esphome-build.outputs.name) || steps.esphome-build.outputs.original-name }}
           path: output
 
   combine:
@@ -111,12 +108,13 @@ jobs:
       - prepare
       - build
     runs-on: ubuntu-latest
-    if: inputs.combined_name != ''
+    if: inputs.combined-name != ''
     steps:
       - name: Download artifacts
         uses: actions/download-artifact@v4.1.8
         with:
           path: files
+          pattern: ${{ needs.prepare.outputs.artifact-prefix }}-*
 
       - name: Get artifact names
         id: artifacts
@@ -146,66 +144,5 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v4.3.4
         with:
-          name: ${{ inputs.combined_name }}
+          name: ${{ inputs.combined-name }}
           path: output
-
-  upload:
-    name: Upload firmware to Cloudflare R2
-    needs:
-      - prepare
-      - build
-    runs-on: ubuntu-latest
-    if: inputs.upload
-    steps:
-      - name: Download artifacts
-        uses: actions/download-artifact@v4.1.8
-        with:
-          path: files
-
-      - run: tree
-
-      - name: Upload files to R2
-        uses: ryand56/r2-upload-action@v1.3.2
-        with:
-          r2-account-id: ${{ secrets.CLOUDFLARE_R2_ACCOUNT_ID }}
-          r2-access-key-id: ${{ secrets.CLOUDFLARE_R2_ACCESS_KEY_ID }}
-          r2-secret-access-key: ${{ secrets.CLOUDFLARE_R2_SECRET_ACCESS_KEY }}
-          r2-bucket: ${{ secrets.CLOUDFLARE_R2_BUCKET }}
-          source-dir: files
-          destination-dir: ${{ inputs.name }}/
-
-  promote:
-    name: Promote firmware to production
-    needs:
-      - prepare
-      - upload
-    runs-on: ubuntu-latest
-    environment: production
-    if: inputs.upload && inputs.release-version != ''
-    steps:
-      - name: Download artifacts
-        uses: actions/download-artifact@v4.1.8
-        with:
-          path: files
-
-      - name: Copy manifest.json
-        run: |
-          mkdir -p output
-          version="${{ needs.prepare.outputs.version }}"
-          for device in files/*; do
-            device=$(basename $device)
-            mkdir -p output/$device
-            jq --arg version "$version" \
-              '.builds[].ota.path |= $version + "/" + . | .builds[].parts[].path |= $version + "/" + .' \
-              files/$device/$version/manifest.json > output/$device/manifest.json
-          done
-
-      - name: Upload files to R2
-        uses: ryand56/r2-upload-action@v1.3.2
-        with:
-          r2-account-id: ${{ secrets.CLOUDFLARE_R2_ACCOUNT_ID }}
-          r2-access-key-id: ${{ secrets.CLOUDFLARE_R2_ACCESS_KEY_ID }}
-          r2-secret-access-key: ${{ secrets.CLOUDFLARE_R2_SECRET_ACCESS_KEY }}
-          r2-bucket: ${{ secrets.CLOUDFLARE_R2_BUCKET }}
-          source-dir: output
-          destination-dir: ${{ inputs.name }}/

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -1,0 +1,74 @@
+name: Upload
+# This workflow is only to be used within the ESPHome organisation on GitHub.
+# It is used to build and upload the binaries to Cloudflare R2 and only
+# specific repositories will be granted the secrets required to do so.
+
+on:
+  workflow_call:
+    inputs:
+      name:
+        description: Name of the firmware to upload
+        required: false
+        type: string
+      version:
+        description: Version of the release
+        required: false
+        type: string
+        default: ""
+
+jobs:
+  upload:
+    name: Upload firmware to Cloudflare R2
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4.1.8
+        with:
+          path: files
+
+      - run: tree
+
+      - name: Upload files to R2
+        uses: ryand56/r2-upload-action@v1.3.2
+        with:
+          r2-account-id: ${{ secrets.CLOUDFLARE_R2_ACCOUNT_ID }}
+          r2-access-key-id: ${{ secrets.CLOUDFLARE_R2_ACCESS_KEY_ID }}
+          r2-secret-access-key: ${{ secrets.CLOUDFLARE_R2_SECRET_ACCESS_KEY }}
+          r2-bucket: ${{ secrets.CLOUDFLARE_R2_BUCKET }}
+          source-dir: files
+          destination-dir: ${{ inputs.name }}/
+
+  promote:
+    name: Promote firmware to production
+    needs:
+      - upload
+    runs-on: ubuntu-latest
+    environment: production
+    if: inputs.version != ''
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4.1.8
+        with:
+          path: files
+
+      - name: Copy manifest.json
+        run: |
+          mkdir -p output
+          version="${{ inputs.version }}"
+          for device in files/*; do
+            device=$(basename $device)
+            mkdir -p output/$device
+            jq --arg version "$version" \
+              '.builds[].ota.path |= $version + "/" + . | .builds[].parts[].path |= $version + "/" + .' \
+              files/$device/$version/manifest.json > output/$device/manifest.json
+          done
+
+      - name: Upload files to R2
+        uses: ryand56/r2-upload-action@v1.3.2
+        with:
+          r2-account-id: ${{ secrets.CLOUDFLARE_R2_ACCOUNT_ID }}
+          r2-access-key-id: ${{ secrets.CLOUDFLARE_R2_ACCESS_KEY_ID }}
+          r2-secret-access-key: ${{ secrets.CLOUDFLARE_R2_SECRET_ACCESS_KEY }}
+          r2-bucket: ${{ secrets.CLOUDFLARE_R2_BUCKET }}
+          source-dir: output
+          destination-dir: ${{ inputs.name }}/


### PR DESCRIPTION
- Add input and job to combine manifests for multi-variant builds
- Split build and upload jobs to allow for multiple build jobs before uploading all