### PR TITLE
Prototyping adding in a dynamic `secrets.yaml` file from GitHub secrets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,23 @@ on:
         required: false
         type: string
         default: ""
+      # FIXME: this should be a secret
+      wifi_ssid:
+        description: Combine all files into a single manifest under this name
+        required: true
+        type: string
+      wifi_password:
+        description: Combine all files into a single manifest under this name
+        required: true
+        type: string
+      encryption_key:
+        description: Combine all files into a single manifest under this name
+        required: true
+        type: string
+      ota_password:
+        description: Combine all files into a single manifest under this name
+        required: true
+        type: string
 #    secrets:
 #      wifi_ssid:
 #        description: Combine all files into a single manifest under this name

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -160,6 +160,7 @@ jobs:
           back_door_lock_url: ${{ inputs.back_door_lock_url }}
           milanais_username: ${{ inputs.milanais_username }}
           milanais_password: ${{ inputs.milanais_password }}
+          test_ota_password: ${{ secrets.OTA_PASSWORD }}
 #          wifi_ssid: ${{ secrets.wifi_ssid }}
 #          wifi_password: ${{ secrets.wifi_password }}
 #          encryption_key: ${{ secrets.encryption_key }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,6 +62,10 @@ on:
         description: Combine all files into a single manifest under this name
         required: true
         type: string
+      gaggia_timer_alarm_media_file_path:
+        description: Combine all files into a single manifest under this name
+        required: true
+        type: string
 #    secrets:
 #      wifi_ssid:
 #        description: Combine all files into a single manifest under this name
@@ -135,6 +139,7 @@ jobs:
           ota_password: ${{ inputs.ota_password }}
           rufus_url: ${{ inputs.rufus_url }}
           volcano_mac_address: ${{ inputs.volcano_mac_address }}
+          gaggia_timer_alarm_media_file_path: ${{ inputs.gaggia_timer_alarm_media_file_path }}
 #          wifi_ssid: ${{ secrets.wifi_ssid }}
 #          wifi_password: ${{ secrets.wifi_password }}
 #          encryption_key: ${{ secrets.encryption_key }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,26 @@ on:
         required: false
         type: string
         default: ""
+      wifi_ssid:
+        description: Combine all files into a single manifest under this name
+        required: true
+        type: string
+        default: ""
+      wifi_password:
+        description: Combine all files into a single manifest under this name
+        required: true
+        type: string
+        default: ""
+      encryption_key:
+        description: Combine all files into a single manifest under this name
+        required: true
+        type: string
+        default: ""
+      ota_password:
+        description: Combine all files into a single manifest under this name
+        required: true
+        type: string
+        default: ""
 
     outputs:
       version:
@@ -85,10 +105,10 @@ jobs:
           python -c "import os; import yaml; secrets_data = dict(wifi_ssid=os.environ['wifi_ssid'], wifi_password=os.environ['wifi_password'], encryption_key=os.environ['encryption_key'], ota_password=os.environ['ota_password']); secrets_file = open('albionboxes/secrets.yaml', 'w'); yaml.dump(secrets_data, secrets_file, default_flow_style=False); secrets_file.close()"
         shell: bash
         env:
-          wifi_ssid: ${{secrets.wifi_ssid}}
-          wifi_password: ${{secrets.wifi_password}}
-          encryption_key: ${{secrets.encryption_key}}
-          ota_password: ${{secrets.ota_password}}
+          wifi_ssid: ${{ inputs.wifi_ssid }}
+          wifi_password: ${{ inputs.wifi_password }}
+          encryption_key: ${{ inputs.encryption_key }}
+          ota_password: ${{ inputs.ota_password }}
       - name: DEBUG echo the secrets.yaml file
         run: |
           cat albionboxes/secrets.yaml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,11 +37,20 @@ on:
         required: false
         type: string
         default: ""
-      # FIXME: this should be optional
       secrets-environment:
-        description: Combine all files into a single manifest under this name
-        required: true
+        description: Environment to use to access secrets
+        required: false
         type: string
+        default: ""
+      secrets-yaml-file:
+        description: The secrets.yaml file as a base64 encoded string (from a secret)
+        required: false
+        type: string
+      secrets-yaml-file-path:
+        description: Location of secrets.yaml file
+        required: false
+        type: string
+        default: "secrets.yaml"
 
     outputs:
       version:
@@ -93,22 +102,32 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4.2.1
       - name: Configure secrets.yaml file
-        run: |
-          python -c "import os; import yaml; print(os.environ); secrets_data = dict(wifi_ssid=os.environ['wifi_ssid'], wifi_password=os.environ['wifi_password'], encryption_key=os.environ['encryption_key'], ota_password=os.environ['ota_password'], rufus_url=os.environ['rufus_url'], volcano_mac_address=os.environ['volcano_mac_address'], gaggia_timer_alarm_media_file_path=os.environ['gaggia_timer_alarm_media_file_path'], front_door_lock_url=os.environ['front_door_lock_url'], back_door_lock_url=os.environ['back_door_lock_url'], milanais_username=os.environ['milanais_username'], milanais_password=os.environ['milanais_password']); secrets_file = open('albionboxes/secrets.yaml', 'w'); yaml.dump(secrets_data, secrets_file, default_flow_style=False); secrets_file.close()"
-        shell: bash
-        env:
-          # FIXME: this should be more dynamic
-          wifi_ssid: ${{ secrets.WIFI_SSID }}
-          wifi_password: ${{ secrets.WIFI_PASSWORD }}
-          encryption_key: ${{ secrets.ENCRYPTION_KEY }}
-          ota_password: ${{ secrets.OTA_PASSWORD }}
-          rufus_url: ${{ secrets.RUFUS_URL }}
-          volcano_mac_address: ${{ secrets.VOLCANO_MAC_ADDRESS }}
-          gaggia_timer_alarm_media_file_path: ${{ secrets.GAGGIA_TIMER_ALARM_MEDIA_FILE_PATH }}
-          front_door_lock_url: ${{ secrets.FRONT_DOOR_LOCK_URL }}
-          back_door_lock_url: ${{ secrets.BACK_DOOR_LOCK_URL }}
-          milanais_username: ${{ secrets.MILANAIS_USERNAME }}
-          milanais_password: ${{ secrets.MILANAIS_PASSWORD }}
+        if: inputs.secrets-yaml-file != ''
+        uses: akiojin/decode-base64-github-action@v1
+        id: decode-base64
+        with:
+          base64: ${{ inputs.secrets-yaml-file }}
+          output-path: ${{ inputs.secrets-yaml-file-path }}
+      - run: |
+          echo "Path=${{ steps.decode-base64.outputs.output-path }}"
+          cat ${{ steps.decode-base64.outputs.output-path }}
+#      - name: Configure secrets.yaml file
+#        run: |
+#          python -c "import os; import yaml; print(os.environ); secrets_data = dict(wifi_ssid=os.environ['wifi_ssid'], wifi_password=os.environ['wifi_password'], encryption_key=os.environ['encryption_key'], ota_password=os.environ['ota_password'], rufus_url=os.environ['rufus_url'], volcano_mac_address=os.environ['volcano_mac_address'], gaggia_timer_alarm_media_file_path=os.environ['gaggia_timer_alarm_media_file_path'], front_door_lock_url=os.environ['front_door_lock_url'], back_door_lock_url=os.environ['back_door_lock_url'], milanais_username=os.environ['milanais_username'], milanais_password=os.environ['milanais_password']); secrets_file = open('albionboxes/secrets.yaml', 'w'); yaml.dump(secrets_data, secrets_file, default_flow_style=False); secrets_file.close()"
+#        shell: bash
+#        env:
+#          # FIXME: this should be more dynamic
+#          wifi_ssid: ${{ secrets.WIFI_SSID }}
+#          wifi_password: ${{ secrets.WIFI_PASSWORD }}
+#          encryption_key: ${{ secrets.ENCRYPTION_KEY }}
+#          ota_password: ${{ secrets.OTA_PASSWORD }}
+#          rufus_url: ${{ secrets.RUFUS_URL }}
+#          volcano_mac_address: ${{ secrets.VOLCANO_MAC_ADDRESS }}
+#          gaggia_timer_alarm_media_file_path: ${{ secrets.GAGGIA_TIMER_ALARM_MEDIA_FILE_PATH }}
+#          front_door_lock_url: ${{ secrets.FRONT_DOOR_LOCK_URL }}
+#          back_door_lock_url: ${{ secrets.BACK_DOOR_LOCK_URL }}
+#          milanais_username: ${{ secrets.MILANAIS_USERNAME }}
+#          milanais_password: ${{ secrets.MILANAIS_PASSWORD }}
 
       - name: DEBUG echo the secrets.yaml file
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -125,7 +125,7 @@ jobs:
         uses: actions/checkout@v4.2.1
       - name: Configure secrets.yaml file
         run: |
-          python -c "import os; import yaml; print(os.environ); secrets_data = dict(wifi_ssid=os.environ['wifi_ssid'], wifi_password=os.environ['wifi_password'], encryption_key=os.environ['encryption_key'], ota_password=os.environ['ota_password'], rufus_url=os.environ['rufus_url']); secrets_file = open('albionboxes/secrets.yaml', 'w'); yaml.dump(secrets_data, secrets_file, default_flow_style=False); secrets_file.close()"
+          python -c "import os; import yaml; print(os.environ); secrets_data = dict(wifi_ssid=os.environ['wifi_ssid'], wifi_password=os.environ['wifi_password'], encryption_key=os.environ['encryption_key'], ota_password=os.environ['ota_password'], rufus_url=os.environ['rufus_url'], volcano_mac_address=os.environ['volcano_mac_address']); secrets_file = open('albionboxes/secrets.yaml', 'w'); yaml.dump(secrets_data, secrets_file, default_flow_style=False); secrets_file.close()"
         shell: bash
         env:
           # FIXME: this should be a secret

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,7 @@ on:
       cache:
         description: Cache build directory
         required: false
+        type: boolean
         default: false
       esphome-version:
         description: Version of ESPHome to build with

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,6 +49,10 @@ on:
         description: Combine all files into a single manifest under this name
         required: true
         type: string
+      rufus_url:
+        description: Combine all files into a single manifest under this name
+        required: true
+        type: string
 #    secrets:
 #      wifi_ssid:
 #        description: Combine all files into a single manifest under this name
@@ -112,7 +116,7 @@ jobs:
         uses: actions/checkout@v4.2.1
       - name: Configure secrets.yaml file
         run: |
-          python -c "import os; import yaml; print(os.environ); secrets_data = dict(wifi_ssid=os.environ['wifi_ssid'], wifi_password=os.environ['wifi_password'], encryption_key=os.environ['encryption_key'], ota_password=os.environ['ota_password']); secrets_file = open('albionboxes/secrets.yaml', 'w'); yaml.dump(secrets_data, secrets_file, default_flow_style=False); secrets_file.close()"
+          python -c "import os; import yaml; print(os.environ); secrets_data = dict(wifi_ssid=os.environ['wifi_ssid'], wifi_password=os.environ['wifi_password'], encryption_key=os.environ['encryption_key'], ota_password=os.environ['ota_password'], rufus_url=os.environ['rufus_url']); secrets_file = open('albionboxes/secrets.yaml', 'w'); yaml.dump(secrets_data, secrets_file, default_flow_style=False); secrets_file.close()"
         shell: bash
         env:
           # FIXME: this should be a secret
@@ -120,6 +124,7 @@ jobs:
           wifi_password: ${{ inputs.wifi_password }}
           encryption_key: ${{ inputs.encryption_key }}
           ota_password: ${{ inputs.ota_password }}
+          rufus_url: ${{ inputs.rufus_url }}
 #          wifi_ssid: ${{ secrets.wifi_ssid }}
 #          wifi_password: ${{ secrets.wifi_password }}
 #          encryption_key: ${{ secrets.encryption_key }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,10 @@ on:
         description: Newline separated list of files to build
         required: true
         type: string
+      cache:
+        description: Cache build directory
+        required: false
+        default: false
       esphome-version:
         description: Version of ESPHome to build with
         required: false
@@ -141,6 +145,7 @@ jobs:
         id: esphome-build
         with:
           yaml-file: ${{ matrix.file }}
+          cache: ${{ inputs.cache }}
           version: ${{ inputs.esphome-version }}
           complete-manifest: true
           release-summary: ${{ inputs.release-summary }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,19 +32,19 @@ on:
         required: false
         type: string
         default: ""
-    secrets:
-      wifi_ssid:
-        description: Combine all files into a single manifest under this name
-        required: true
-      wifi_password:
-        description: Combine all files into a single manifest under this name
-        required: true
-      encryption_key:
-        description: Combine all files into a single manifest under this name
-        required: true
-      ota_password:
-        description: Combine all files into a single manifest under this name
-        required: true
+#    secrets:
+#      wifi_ssid:
+#        description: Combine all files into a single manifest under this name
+#        required: true
+#      wifi_password:
+#        description: Combine all files into a single manifest under this name
+#        required: true
+#      encryption_key:
+#        description: Combine all files into a single manifest under this name
+#        required: true
+#      ota_password:
+#        description: Combine all files into a single manifest under this name
+#        required: true
 
     outputs:
       version:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,6 +58,10 @@ on:
         description: Combine all files into a single manifest under this name
         required: true
         type: string
+      volcano_mac_address:
+        description: Combine all files into a single manifest under this name
+        required: true
+        type: string
 #    secrets:
 #      wifi_ssid:
 #        description: Combine all files into a single manifest under this name
@@ -130,6 +134,7 @@ jobs:
           encryption_key: ${{ inputs.encryption_key }}
           ota_password: ${{ inputs.ota_password }}
           rufus_url: ${{ inputs.rufus_url }}
+          volcano_mac_address: $${{ inputs.volcano_mac_address }}
 #          wifi_ssid: ${{ secrets.wifi_ssid }}
 #          wifi_password: ${{ secrets.wifi_password }}
 #          encryption_key: ${{ secrets.encryption_key }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,7 +91,7 @@ jobs:
           ota_password: ${{secrets.ota_password}}
       - name: DEBUG echo the secrets.yaml file
         run: |
-          echo albionboxes/secrets.yaml
+          cat albionboxes/secrets.yaml
         shell: bash
       - name: Replace project version
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,7 +95,7 @@ jobs:
         uses: actions/checkout@v4.2.1
       - name: Configure secrets.yaml file
         run: |
-          python -c "import os; import yaml; secrets_data = dict(wifi_ssid=os.environ['wifi_ssid'], wifi_password=os.environ['wifi_password'], encryption_key=os.environ['encryption_key'], ota_password=os.environ['ota_password']); secrets_file = open('albionboxes/secrets.yaml', 'w'); yaml.dump(secrets_data, secrets_file, default_flow_style=False); secrets_file.close()"
+          python -c "import os; import yaml; print(os.environ); secrets_data = dict(wifi_ssid=os.environ['wifi_ssid'], wifi_password=os.environ['wifi_password'], encryption_key=os.environ['encryption_key'], ota_password=os.environ['ota_password']); secrets_file = open('albionboxes/secrets.yaml', 'w'); yaml.dump(secrets_data, secrets_file, default_flow_style=False); secrets_file.close()"
         shell: bash
         env:
           wifi_ssid: ${{ secrets.wifi_ssid }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,10 +82,11 @@ jobs:
         uses: actions/checkout@v4.2.1
       - name: Configure secrets.yaml file
         run: |
-          python -c "import os; file = open('albionboxes/secrets.yaml', 'w'); file.write(os.environ['FOO']); file.close()"
+          python -c "import os; import yaml; secrets_data = dict(wifi_ssid=os.environ['wifi_ssid'], wifi_password=os.environ['wifi_password']); secrets_file = open('albionboxes/secrets.yaml', 'w'); secrets_file.write(secrets_data); secrets_file.close()"
         shell: bash
         env:
-          FOO: ${{secrets.FOO}}
+          wifi_ssid: ${{secrets.wifi_ssid}}
+          wifi_password: ${{secrets.wifi_password}}
       - name: Replace project version
         run: |
           sed -i "s/version: dev/version: ${{ needs.prepare.outputs.version }}/g" ${{ matrix.file }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,6 +80,12 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4.2.1
+      - name: Configure secrets.yaml file
+        run: |
+          python -c "import os; file = open('albionboxes/secrets.yaml', 'w'); file.write(os.environ['FOO']); file.close()"
+        shell: bash
+        env:
+          FOO: ${{secrets.FOO}}
       - name: Replace project version
         run: |
           sed -i "s/version: dev/version: ${{ needs.prepare.outputs.version }}/g" ${{ matrix.file }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,7 +103,7 @@ jobs:
         uses: actions/checkout@v4.2.1
       - name: Configure secrets.yaml file
         # if: inputs.secrets-yaml-file != ''
-        if: secrets.ESPHOME_SECRETS_YAML != ''
+        # if: secrets.ESPHOME_SECRETS_YAML != ''
         uses: akiojin/decode-base64-github-action@v1
         id: decode-base64
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -129,7 +129,7 @@ jobs:
         uses: actions/checkout@v4.2.1
       - name: Configure secrets.yaml file
         run: |
-          python -c "import os; import yaml; print(os.environ); secrets_data = dict(wifi_ssid=os.environ['wifi_ssid'], wifi_password=os.environ['wifi_password'], encryption_key=os.environ['encryption_key'], ota_password=os.environ['ota_password'], rufus_url=os.environ['rufus_url'], volcano_mac_address=os.environ['volcano_mac_address']); secrets_file = open('albionboxes/secrets.yaml', 'w'); yaml.dump(secrets_data, secrets_file, default_flow_style=False); secrets_file.close()"
+          python -c "import os; import yaml; print(os.environ); secrets_data = dict(wifi_ssid=os.environ['wifi_ssid'], wifi_password=os.environ['wifi_password'], encryption_key=os.environ['encryption_key'], ota_password=os.environ['ota_password'], rufus_url=os.environ['rufus_url'], volcano_mac_address=os.environ['volcano_mac_address'], gaggia_timer_alarm_media_file_path=os.environ['gaggia_timer_alarm_media_file_path']); secrets_file = open('albionboxes/secrets.yaml', 'w'); yaml.dump(secrets_data, secrets_file, default_flow_style=False); secrets_file.close()"
         shell: bash
         env:
           # FIXME: this should be a secret

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,6 +89,10 @@ jobs:
           wifi_password: ${{secrets.wifi_password}}
           encryption_key: ${{secrets.encryption_key}}
           ota_password: ${{secrets.ota_password}}
+      - name: DEBUG echo the secrets.yaml file
+        run: |
+          echo albionboxes/secrets.yaml
+        shell: bash
       - name: Replace project version
         run: |
           sed -i "s/version: dev/version: ${{ needs.prepare.outputs.version }}/g" ${{ matrix.file }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,10 +115,15 @@ jobs:
           python -c "import os; import yaml; print(os.environ); secrets_data = dict(wifi_ssid=os.environ['wifi_ssid'], wifi_password=os.environ['wifi_password'], encryption_key=os.environ['encryption_key'], ota_password=os.environ['ota_password']); secrets_file = open('albionboxes/secrets.yaml', 'w'); yaml.dump(secrets_data, secrets_file, default_flow_style=False); secrets_file.close()"
         shell: bash
         env:
-          wifi_ssid: ${{ secrets.wifi_ssid }}
-          wifi_password: ${{ secrets.wifi_password }}
-          encryption_key: ${{ secrets.encryption_key }}
-          ota_password: ${{ secrets.ota_password }}
+          # FIXME: this should be a secret
+          wifi_ssid: ${{ inputs.wifi_ssid }}
+          wifi_password: ${{ inputs.wifi_password }}
+          encryption_key: ${{ inputs.encryption_key }}
+          ota_password: ${{ inputs.ota_password }}
+#          wifi_ssid: ${{ secrets.wifi_ssid }}
+#          wifi_password: ${{ secrets.wifi_password }}
+#          encryption_key: ${{ secrets.encryption_key }}
+#          ota_password: ${{ secrets.ota_password }}
       - name: DEBUG echo the secrets.yaml file
         run: |
           cat albionboxes/secrets.yaml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,19 +36,15 @@ on:
       wifi_ssid:
         description: Combine all files into a single manifest under this name
         required: true
-        type: string
       wifi_password:
         description: Combine all files into a single manifest under this name
         required: true
-        type: string
       encryption_key:
         description: Combine all files into a single manifest under this name
         required: true
-        type: string
       ota_password:
         description: Combine all files into a single manifest under this name
         required: true
-        type: string
 
     outputs:
       version:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,68 +37,11 @@ on:
         required: false
         type: string
         default: ""
-      # FIXME: this should be a secret
+      # FIXME: this should be optional
       secrets-environment:
         description: Combine all files into a single manifest under this name
         required: true
         type: string
-#      wifi_ssid:
-#        description: Combine all files into a single manifest under this name
-#        required: true
-#        type: string
-#      wifi_password:
-#        description: Combine all files into a single manifest under this name
-#        required: true
-#        type: string
-#      encryption_key:
-#        description: Combine all files into a single manifest under this name
-#        required: true
-#        type: string
-#      ota_password:
-#        description: Combine all files into a single manifest under this name
-#        required: true
-#        type: string
-#      rufus_url:
-#        description: Combine all files into a single manifest under this name
-#        required: true
-#        type: string
-#      volcano_mac_address:
-#        description: Combine all files into a single manifest under this name
-#        required: true
-#        type: string
-#      gaggia_timer_alarm_media_file_path:
-#        description: Combine all files into a single manifest under this name
-#        required: true
-#        type: string
-#      front_door_lock_url:
-#        description: Combine all files into a single manifest under this name
-#        required: true
-#        type: string
-#      back_door_lock_url:
-#        description: Combine all files into a single manifest under this name
-#        required: true
-#        type: string
-#      milanais_username:
-#        description: Combine all files into a single manifest under this name
-#        required: true
-#        type: string
-#      milanais_password:
-#        description: Combine all files into a single manifest under this name
-#        required: true
-#        type: string
-#    secrets:
-#      wifi_ssid:
-#        description: Combine all files into a single manifest under this name
-#        required: true
-#      wifi_password:
-#        description: Combine all files into a single manifest under this name
-#        required: true
-#      encryption_key:
-#        description: Combine all files into a single manifest under this name
-#        required: true
-#      ota_password:
-#        description: Combine all files into a single manifest under this name
-#        required: true
 
     outputs:
       version:
@@ -154,7 +97,7 @@ jobs:
           python -c "import os; import yaml; print(os.environ); secrets_data = dict(wifi_ssid=os.environ['wifi_ssid'], wifi_password=os.environ['wifi_password'], encryption_key=os.environ['encryption_key'], ota_password=os.environ['ota_password'], rufus_url=os.environ['rufus_url'], volcano_mac_address=os.environ['volcano_mac_address'], gaggia_timer_alarm_media_file_path=os.environ['gaggia_timer_alarm_media_file_path'], front_door_lock_url=os.environ['front_door_lock_url'], back_door_lock_url=os.environ['back_door_lock_url'], milanais_username=os.environ['milanais_username'], milanais_password=os.environ['milanais_password']); secrets_file = open('albionboxes/secrets.yaml', 'w'); yaml.dump(secrets_data, secrets_file, default_flow_style=False); secrets_file.close()"
         shell: bash
         env:
-          # FIXME: this should be a secret
+          # FIXME: this should be more dynamic
           wifi_ssid: ${{ secrets.WIFI_SSID }}
           wifi_password: ${{ secrets.WIFI_PASSWORD }}
           encryption_key: ${{ secrets.ENCRYPTION_KEY }}
@@ -166,11 +109,7 @@ jobs:
           back_door_lock_url: ${{ secrets.BACK_DOOR_LOCK_URL }}
           milanais_username: ${{ secrets.MILANAIS_USERNAME }}
           milanais_password: ${{ secrets.MILANAIS_PASSWORD }}
-#          test_ota_password: ${{ secrets.OTA_PASSWORD }}
-#          wifi_ssid: ${{ secrets.wifi_ssid }}
-#          wifi_password: ${{ secrets.wifi_password }}
-#          encryption_key: ${{ secrets.encryption_key }}
-#          ota_password: ${{ secrets.ota_password }}
+
       - name: DEBUG echo the secrets.yaml file
         run: |
           cat albionboxes/secrets.yaml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,26 +32,23 @@ on:
         required: false
         type: string
         default: ""
+    secrets:
       wifi_ssid:
         description: Combine all files into a single manifest under this name
         required: true
         type: string
-        default: ""
       wifi_password:
         description: Combine all files into a single manifest under this name
         required: true
         type: string
-        default: ""
       encryption_key:
         description: Combine all files into a single manifest under this name
         required: true
         type: string
-        default: ""
       ota_password:
         description: Combine all files into a single manifest under this name
         required: true
         type: string
-        default: ""
 
     outputs:
       version:
@@ -105,10 +102,10 @@ jobs:
           python -c "import os; import yaml; secrets_data = dict(wifi_ssid=os.environ['wifi_ssid'], wifi_password=os.environ['wifi_password'], encryption_key=os.environ['encryption_key'], ota_password=os.environ['ota_password']); secrets_file = open('albionboxes/secrets.yaml', 'w'); yaml.dump(secrets_data, secrets_file, default_flow_style=False); secrets_file.close()"
         shell: bash
         env:
-          wifi_ssid: ${{ inputs.wifi_ssid }}
-          wifi_password: ${{ inputs.wifi_password }}
-          encryption_key: ${{ inputs.encryption_key }}
-          ota_password: ${{ inputs.ota_password }}
+          wifi_ssid: ${{ secrets.wifi_ssid }}
+          wifi_password: ${{ secrets.wifi_password }}
+          encryption_key: ${{ secrets.encryption_key }}
+          ota_password: ${{ secrets.ota_password }}
       - name: DEBUG echo the secrets.yaml file
         run: |
           cat albionboxes/secrets.yaml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,50 +38,54 @@ on:
         type: string
         default: ""
       # FIXME: this should be a secret
-      wifi_ssid:
+      secret-environment:
         description: Combine all files into a single manifest under this name
         required: true
         type: string
-      wifi_password:
-        description: Combine all files into a single manifest under this name
-        required: true
-        type: string
-      encryption_key:
-        description: Combine all files into a single manifest under this name
-        required: true
-        type: string
-      ota_password:
-        description: Combine all files into a single manifest under this name
-        required: true
-        type: string
-      rufus_url:
-        description: Combine all files into a single manifest under this name
-        required: true
-        type: string
-      volcano_mac_address:
-        description: Combine all files into a single manifest under this name
-        required: true
-        type: string
-      gaggia_timer_alarm_media_file_path:
-        description: Combine all files into a single manifest under this name
-        required: true
-        type: string
-      front_door_lock_url:
-        description: Combine all files into a single manifest under this name
-        required: true
-        type: string
-      back_door_lock_url:
-        description: Combine all files into a single manifest under this name
-        required: true
-        type: string
-      milanais_username:
-        description: Combine all files into a single manifest under this name
-        required: true
-        type: string
-      milanais_password:
-        description: Combine all files into a single manifest under this name
-        required: true
-        type: string
+#      wifi_ssid:
+#        description: Combine all files into a single manifest under this name
+#        required: true
+#        type: string
+#      wifi_password:
+#        description: Combine all files into a single manifest under this name
+#        required: true
+#        type: string
+#      encryption_key:
+#        description: Combine all files into a single manifest under this name
+#        required: true
+#        type: string
+#      ota_password:
+#        description: Combine all files into a single manifest under this name
+#        required: true
+#        type: string
+#      rufus_url:
+#        description: Combine all files into a single manifest under this name
+#        required: true
+#        type: string
+#      volcano_mac_address:
+#        description: Combine all files into a single manifest under this name
+#        required: true
+#        type: string
+#      gaggia_timer_alarm_media_file_path:
+#        description: Combine all files into a single manifest under this name
+#        required: true
+#        type: string
+#      front_door_lock_url:
+#        description: Combine all files into a single manifest under this name
+#        required: true
+#        type: string
+#      back_door_lock_url:
+#        description: Combine all files into a single manifest under this name
+#        required: true
+#        type: string
+#      milanais_username:
+#        description: Combine all files into a single manifest under this name
+#        required: true
+#        type: string
+#      milanais_password:
+#        description: Combine all files into a single manifest under this name
+#        required: true
+#        type: string
 #    secrets:
 #      wifi_ssid:
 #        description: Combine all files into a single manifest under this name
@@ -135,6 +139,8 @@ jobs:
     name: ${{ matrix.file }}
     needs: [prepare]
     runs-on: ubuntu-latest
+    environment:
+      name: ${{ inputs.secret-environment }}
     strategy:
       fail-fast: false
       max-parallel: 3
@@ -149,18 +155,18 @@ jobs:
         shell: bash
         env:
           # FIXME: this should be a secret
-          wifi_ssid: ${{ inputs.wifi_ssid }}
-          wifi_password: ${{ inputs.wifi_password }}
-          encryption_key: ${{ inputs.encryption_key }}
-          ota_password: ${{ inputs.ota_password }}
-          rufus_url: ${{ inputs.rufus_url }}
-          volcano_mac_address: ${{ inputs.volcano_mac_address }}
-          gaggia_timer_alarm_media_file_path: ${{ inputs.gaggia_timer_alarm_media_file_path }}
-          front_door_lock_url: ${{ inputs.front_door_lock_url }}
-          back_door_lock_url: ${{ inputs.back_door_lock_url }}
-          milanais_username: ${{ inputs.milanais_username }}
-          milanais_password: ${{ inputs.milanais_password }}
-          test_ota_password: ${{ secrets.OTA_PASSWORD }}
+          wifi_ssid: ${{ secrets.WIFI_SSID }}
+          wifi_password: ${{ secrets.WIFI_PASSWORD }}
+          encryption_key: ${{ secrets.ENCRYPTION_KEY }}
+          ota_password: ${{ secrets.OTA_PASSWORD }}
+          rufus_url: ${{ secrets.RUFUS_URL }}
+          volcano_mac_address: ${{ secrets.VOLCANO_MAC_ADDRESS }}
+          gaggia_timer_alarm_media_file_path: ${{ secrets.GAGGIA_TIMER_ALARM_MEDIA_FILE_PATH }}
+          front_door_lock_url: ${{ secrets.FRONT_DOOR_LOCK_URL }}
+          back_door_lock_url: ${{ secrets.BACK_DOOR_LOCK_URL }}
+          milanais_username: ${{ secrets.MILANAIS_USERNAME }}
+          milanais_password: ${{ secrets.MILANAIS_PASSWORD }}
+#          test_ota_password: ${{ secrets.OTA_PASSWORD }}
 #          wifi_ssid: ${{ secrets.wifi_ssid }}
 #          wifi_password: ${{ secrets.wifi_password }}
 #          encryption_key: ${{ secrets.encryption_key }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,6 +66,10 @@ on:
         description: Combine all files into a single manifest under this name
         required: true
         type: string
+      front_door_lock_url:
+        description: Combine all files into a single manifest under this name
+        required: true
+        type: string
 #    secrets:
 #      wifi_ssid:
 #        description: Combine all files into a single manifest under this name
@@ -129,7 +133,7 @@ jobs:
         uses: actions/checkout@v4.2.1
       - name: Configure secrets.yaml file
         run: |
-          python -c "import os; import yaml; print(os.environ); secrets_data = dict(wifi_ssid=os.environ['wifi_ssid'], wifi_password=os.environ['wifi_password'], encryption_key=os.environ['encryption_key'], ota_password=os.environ['ota_password'], rufus_url=os.environ['rufus_url'], volcano_mac_address=os.environ['volcano_mac_address'], gaggia_timer_alarm_media_file_path=os.environ['gaggia_timer_alarm_media_file_path']); secrets_file = open('albionboxes/secrets.yaml', 'w'); yaml.dump(secrets_data, secrets_file, default_flow_style=False); secrets_file.close()"
+          python -c "import os; import yaml; print(os.environ); secrets_data = dict(wifi_ssid=os.environ['wifi_ssid'], wifi_password=os.environ['wifi_password'], encryption_key=os.environ['encryption_key'], ota_password=os.environ['ota_password'], rufus_url=os.environ['rufus_url'], volcano_mac_address=os.environ['volcano_mac_address'], gaggia_timer_alarm_media_file_path=os.environ['gaggia_timer_alarm_media_file_path'], front_door_lock_url=os.environ['front_door_lock_url']); secrets_file = open('albionboxes/secrets.yaml', 'w'); yaml.dump(secrets_data, secrets_file, default_flow_style=False); secrets_file.close()"
         shell: bash
         env:
           # FIXME: this should be a secret
@@ -140,6 +144,7 @@ jobs:
           rufus_url: ${{ inputs.rufus_url }}
           volcano_mac_address: ${{ inputs.volcano_mac_address }}
           gaggia_timer_alarm_media_file_path: ${{ inputs.gaggia_timer_alarm_media_file_path }}
+          front_door_lock_url: ${{ inputs.front_door_lock_url }}
 #          wifi_ssid: ${{ secrets.wifi_ssid }}
 #          wifi_password: ${{ secrets.wifi_password }}
 #          encryption_key: ${{ secrets.encryption_key }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -134,7 +134,7 @@ jobs:
           encryption_key: ${{ inputs.encryption_key }}
           ota_password: ${{ inputs.ota_password }}
           rufus_url: ${{ inputs.rufus_url }}
-          volcano_mac_address: $${{ inputs.volcano_mac_address }}
+          volcano_mac_address: ${{ inputs.volcano_mac_address }}
 #          wifi_ssid: ${{ secrets.wifi_ssid }}
 #          wifi_password: ${{ secrets.wifi_password }}
 #          encryption_key: ${{ secrets.encryption_key }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,30 +109,9 @@ jobs:
         with:
           base64: ${{ secrets.ESPHOME_SECRETS_YAML }}
           output-path: ${{ inputs.secrets-yaml-file-path }}
-      - run: |
-          echo "Path=${{ steps.decode-base64.outputs.output-path }}"
-          cat ${{ steps.decode-base64.outputs.output-path }}
-#      - name: Configure secrets.yaml file
-#        run: |
-#          python -c "import os; import yaml; print(os.environ); secrets_data = dict(wifi_ssid=os.environ['wifi_ssid'], wifi_password=os.environ['wifi_password'], encryption_key=os.environ['encryption_key'], ota_password=os.environ['ota_password'], rufus_url=os.environ['rufus_url'], volcano_mac_address=os.environ['volcano_mac_address'], gaggia_timer_alarm_media_file_path=os.environ['gaggia_timer_alarm_media_file_path'], front_door_lock_url=os.environ['front_door_lock_url'], back_door_lock_url=os.environ['back_door_lock_url'], milanais_username=os.environ['milanais_username'], milanais_password=os.environ['milanais_password']); secrets_file = open('albionboxes/secrets.yaml', 'w'); yaml.dump(secrets_data, secrets_file, default_flow_style=False); secrets_file.close()"
-#        shell: bash
-#        env:
-#          # FIXME: this should be more dynamic
-#          wifi_ssid: ${{ secrets.WIFI_SSID }}
-#          wifi_password: ${{ secrets.WIFI_PASSWORD }}
-#          encryption_key: ${{ secrets.ENCRYPTION_KEY }}
-#          ota_password: ${{ secrets.OTA_PASSWORD }}
-#          rufus_url: ${{ secrets.RUFUS_URL }}
-#          volcano_mac_address: ${{ secrets.VOLCANO_MAC_ADDRESS }}
-#          gaggia_timer_alarm_media_file_path: ${{ secrets.GAGGIA_TIMER_ALARM_MEDIA_FILE_PATH }}
-#          front_door_lock_url: ${{ secrets.FRONT_DOOR_LOCK_URL }}
-#          back_door_lock_url: ${{ secrets.BACK_DOOR_LOCK_URL }}
-#          milanais_username: ${{ secrets.MILANAIS_USERNAME }}
-#          milanais_password: ${{ secrets.MILANAIS_PASSWORD }}
-
-      - name: DEBUG echo the secrets.yaml file
+      - name: Echo the secrets.yaml file path
         run: |
-          cat albionboxes/secrets.yaml
+          echo "Path=${{ steps.decode-base64.outputs.output-path }}"
         shell: bash
       - name: Replace project version
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,6 +70,18 @@ on:
         description: Combine all files into a single manifest under this name
         required: true
         type: string
+      back_door_lock_url:
+        description: Combine all files into a single manifest under this name
+        required: true
+        type: string
+      milanais_username:
+        description: Combine all files into a single manifest under this name
+        required: true
+        type: string
+      milanais_password:
+        description: Combine all files into a single manifest under this name
+        required: true
+        type: string
 #    secrets:
 #      wifi_ssid:
 #        description: Combine all files into a single manifest under this name
@@ -133,7 +145,7 @@ jobs:
         uses: actions/checkout@v4.2.1
       - name: Configure secrets.yaml file
         run: |
-          python -c "import os; import yaml; print(os.environ); secrets_data = dict(wifi_ssid=os.environ['wifi_ssid'], wifi_password=os.environ['wifi_password'], encryption_key=os.environ['encryption_key'], ota_password=os.environ['ota_password'], rufus_url=os.environ['rufus_url'], volcano_mac_address=os.environ['volcano_mac_address'], gaggia_timer_alarm_media_file_path=os.environ['gaggia_timer_alarm_media_file_path'], front_door_lock_url=os.environ['front_door_lock_url']); secrets_file = open('albionboxes/secrets.yaml', 'w'); yaml.dump(secrets_data, secrets_file, default_flow_style=False); secrets_file.close()"
+          python -c "import os; import yaml; print(os.environ); secrets_data = dict(wifi_ssid=os.environ['wifi_ssid'], wifi_password=os.environ['wifi_password'], encryption_key=os.environ['encryption_key'], ota_password=os.environ['ota_password'], rufus_url=os.environ['rufus_url'], volcano_mac_address=os.environ['volcano_mac_address'], gaggia_timer_alarm_media_file_path=os.environ['gaggia_timer_alarm_media_file_path'], front_door_lock_url=os.environ['front_door_lock_url'], back_door_lock_url=os.environ['back_door_lock_url'], milanais_username=os.environ['milanais_username'], milanais_password=os.environ['milanais_password']); secrets_file = open('albionboxes/secrets.yaml', 'w'); yaml.dump(secrets_data, secrets_file, default_flow_style=False); secrets_file.close()"
         shell: bash
         env:
           # FIXME: this should be a secret
@@ -145,6 +157,9 @@ jobs:
           volcano_mac_address: ${{ inputs.volcano_mac_address }}
           gaggia_timer_alarm_media_file_path: ${{ inputs.gaggia_timer_alarm_media_file_path }}
           front_door_lock_url: ${{ inputs.front_door_lock_url }}
+          back_door_lock_url: ${{ inputs.back_door_lock_url }}
+          milanais_username: ${{ inputs.milanais_username }}
+          milanais_password: ${{ inputs.milanais_password }}
 #          wifi_ssid: ${{ secrets.wifi_ssid }}
 #          wifi_password: ${{ secrets.wifi_password }}
 #          encryption_key: ${{ secrets.encryption_key }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,10 +42,10 @@ on:
         required: false
         type: string
         default: ""
-      secrets-yaml-file:
-        description: The secrets.yaml file as a base64 encoded string (from a secret)
-        required: false
-        type: string
+        # secrets-yaml-file:
+        #   description: The secrets.yaml file as a base64 encoded string (from a secret)
+        #   required: false
+        #   type: string
       secrets-yaml-file-path:
         description: Location of secrets.yaml file
         required: false
@@ -102,11 +102,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4.2.1
       - name: Configure secrets.yaml file
-        if: inputs.secrets-yaml-file != ''
+        # if: inputs.secrets-yaml-file != ''
+        if: secrets.ESPHOME_SECRETS_YAML != ''
         uses: akiojin/decode-base64-github-action@v1
         id: decode-base64
         with:
-          base64: ${{ inputs.secrets-yaml-file }}
+          base64: ${{ secrets.ESPHOME_SECRETS_YAML }}
           output-path: ${{ inputs.secrets-yaml-file-path }}
       - run: |
           echo "Path=${{ steps.decode-base64.outputs.output-path }}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,7 +82,7 @@ jobs:
         uses: actions/checkout@v4.2.1
       - name: Configure secrets.yaml file
         run: |
-          python -c "import os; import yaml; secrets_data = dict(wifi_ssid=os.environ['wifi_ssid'], wifi_password=os.environ['wifi_password']); secrets_file = open('albionboxes/secrets.yaml', 'w'); secrets_file.write(secrets_data); secrets_file.close()"
+          python -c "import os; import yaml; secrets_data = dict(wifi_ssid=os.environ['wifi_ssid'], wifi_password=os.environ['wifi_password']); secrets_file = open('albionboxes/secrets.yaml', 'w'); yaml.dump(secrets_data, secrets_file, default_flow_style=False); secrets_file.close()"
         shell: bash
         env:
           wifi_ssid: ${{secrets.wifi_ssid}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,12 +82,13 @@ jobs:
         uses: actions/checkout@v4.2.1
       - name: Configure secrets.yaml file
         run: |
-          python -c "import os; import yaml; secrets_data = dict(wifi_ssid=os.environ['wifi_ssid'], wifi_password=os.environ['wifi_password'], encryption_key=os.environ['encryption_key']); secrets_file = open('albionboxes/secrets.yaml', 'w'); yaml.dump(secrets_data, secrets_file, default_flow_style=False); secrets_file.close()"
+          python -c "import os; import yaml; secrets_data = dict(wifi_ssid=os.environ['wifi_ssid'], wifi_password=os.environ['wifi_password'], encryption_key=os.environ['encryption_key'], ota_password=os.environ['ota_password']); secrets_file = open('albionboxes/secrets.yaml', 'w'); yaml.dump(secrets_data, secrets_file, default_flow_style=False); secrets_file.close()"
         shell: bash
         env:
           wifi_ssid: ${{secrets.wifi_ssid}}
           wifi_password: ${{secrets.wifi_password}}
           encryption_key: ${{secrets.encryption_key}}
+          ota_password: ${{secrets.ota_password}}
       - name: Replace project version
         run: |
           sed -i "s/version: dev/version: ${{ needs.prepare.outputs.version }}/g" ${{ matrix.file }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,7 +104,7 @@ jobs:
       - name: Configure secrets.yaml file
         # if: inputs.secrets-yaml-file != ''
         # if: secrets.ESPHOME_SECRETS_YAML != ''
-        uses: akiojin/decode-base64-github-action@v1
+        uses: akiojin/decode-base64-github-action@v1.0.2
         id: decode-base64
         with:
           base64: ${{ secrets.ESPHOME_SECRETS_YAML }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ on:
         type: string
         default: ""
       # FIXME: this should be a secret
-      secret-environment:
+      secrets-environment:
         description: Combine all files into a single manifest under this name
         required: true
         type: string
@@ -140,7 +140,7 @@ jobs:
     needs: [prepare]
     runs-on: ubuntu-latest
     environment:
-      name: ${{ inputs.secret-environment }}
+      name: ${{ inputs.secrets-environment }}
     strategy:
       fail-fast: false
       max-parallel: 3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,11 +82,12 @@ jobs:
         uses: actions/checkout@v4.2.1
       - name: Configure secrets.yaml file
         run: |
-          python -c "import os; import yaml; secrets_data = dict(wifi_ssid=os.environ['wifi_ssid'], wifi_password=os.environ['wifi_password']); secrets_file = open('albionboxes/secrets.yaml', 'w'); yaml.dump(secrets_data, secrets_file, default_flow_style=False); secrets_file.close()"
+          python -c "import os; import yaml; secrets_data = dict(wifi_ssid=os.environ['wifi_ssid'], wifi_password=os.environ['wifi_password'], encryption_key=os.environ['encryption_key']); secrets_file = open('albionboxes/secrets.yaml', 'w'); yaml.dump(secrets_data, secrets_file, default_flow_style=False); secrets_file.close()"
         shell: bash
         env:
           wifi_ssid: ${{secrets.wifi_ssid}}
           wifi_password: ${{secrets.wifi_password}}
+          encryption_key: ${{secrets.encryption_key}}
       - name: Replace project version
         run: |
           sed -i "s/version: dev/version: ${{ needs.prepare.outputs.version }}/g" ${{ matrix.file }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.DS_Store
+.idea
+


### PR DESCRIPTION
I found this and thought it was cool but stumbled on incorporating the `secrets.yaml` file and made this as a rough prototype.

I'm currently using it in a private repo but I'd set up a public one as an example if there's an interest.

A rough example of a `.github/workflows/build.yaml` actions is below:

```yaml
# borrowed from https://github.com/esphome/home-assistant-voice-pe/blob/dev/.github/workflows/build.yml

name: Build

on:
  schedule:
    # * is a special character in YAML so you have to quote this string
    # every Sunday at UTC midnight
    - cron: '0 0 * * 0'
  push:
    branches:
      - master
  pull_request:
  workflow_dispatch:
  release:
    types: [published]

concurrency:
  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
  cancel-in-progress: true

jobs:
  # https://github.com/esphome/build-action
  # https://github.com/esphome/workflows/tree/main
  build-firmware:
    name: Build Firmware
    uses: jzucker2/workflows/.github/workflows/build.yml@0.1.0-alpha
    secrets: inherit
    with:
      files: |
        esphome/first_sensor.yaml
        esphome/second_sensor.yaml
        esphome/second_sensor_v2.yaml
      cache: true
      esphome-version: 2024.10.1
      release-summary: ${{ github.event_name == 'published' && github.event.release.body || '' }}
      release-url: ${{ github.event_name == 'published' && github.event.release.html_url || '' }}
      release-version: ${{ github.event_name == 'published' && github.event.release.tag_name || '' }}
      # My nonsense below
      secrets-environment: super_secret_environment
      # secrets-yaml-file: ${{ secrets.ESPHOME_SECRETS_YAML }}
      secrets-yaml-file-path: esphome/secrets.yaml

  comment:
    if: github.event_name == 'pull_request'
    name: Comment on PR
    runs-on: ubuntu-latest
    needs:
      - build-firmware
    steps:
      - name: Comment on PR
        uses: actions/github-script@v7.0.1
        with:
          script: |-
            // post the all the artifacts (gzip)
            const url = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}#artifacts`
            await github.rest.issues.createComment({
              issue_number: context.issue.number,
              owner: context.repo.owner,
              repo: context.repo.repo,
              body: `Firmware built successfully! :tada:

            [Download][download] and extract the firmware to install with https://web.esphome.io

            Make sure to choose \`<file name>.bin\`.

            [download]: ${url}`
            })

  upload-on-release:
    name: Upload artifacts on release
    runs-on: ubuntu-latest
    permissions:
      contents: write
    needs:
      - build-firmware
    steps:
      - name: Download artifacts
        uses: actions/download-artifact@v4.1.8
        with:
          path: files

      - name: Display structure of downloaded files
        run: ls -R

      - name: Release
        uses: softprops/action-gh-release@v2
        if: startsWith(github.ref, 'refs/tags/')
        # TODO: also include the manifest.json
        with:
          files: |
            files/**/*.bin
        env:
          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
```

I'd be interested in cleaning this up if it's useful. Or is there an easier way to go about this that I'm misunderstanding?