### PR TITLE
Remove `publish` workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,60 +29,12 @@ on:
         default: latest
 
 jobs:
-  prepare:
+  removed:
+    name: Workflow removed
     runs-on: ubuntu-latest
-    outputs:
-      files: ${{ steps.files-array.outputs.files }}
     steps:
-      - id: files-array
-        run: |
-          files=$(echo "${{ inputs.files }}" | jq -Rcn 'inputs | . / ","')
-          echo "files=$files" >> $GITHUB_OUTPUT
-
-  build:
-    name: Build ESPHome binary for ${{ matrix.file }}
-    needs: [prepare]
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        file: ${{ fromJson(needs.prepare.outputs.files) }}
-    outputs:
-      esphome-version: ${{ steps.esphome-build.outputs.esphome-version }}
-    steps:
-      - uses: actions/checkout@v4.2.2
-      - uses: esphome/build-action@v3.1.0
-        id: esphome-build
-        with:
-          yaml_file: ${{ matrix.file }}
-          version: ${{ inputs.esphome_version }}
-      - run: |
-          mkdir output
-          mv "${{ steps.esphome-build.outputs.name }}" output/
-      - uses: actions/upload-artifact@v3.1.2
-        with:
-          name: ${{ inputs.name }}
-          path: output
-
-  publish:
-    name: Publish new firmware and website to GitHub Pages
-    runs-on: ubuntu-latest
-    needs: [build]
-    steps:
-      - uses: actions/checkout@v4.2.2
-      - uses: actions/download-artifact@v3.0.2
-        with:
-          path: output
-          name: ${{ inputs.name }}
-
-      - name: Create single manifest.json
-        run: |
-          jq -s '{"name": "${{ inputs.name }}", "version": "${{ needs.build.outputs.esphome-version }}", "home_assistant_domain": "esphome", "new_install_skip_erase": false, "builds":.}' output/*/manifest.json > output/${{ inputs.manifest_filename }}
-
-      - run: cp -R static/* output
-
-      - name: Deploy 🚀
-        uses: JamesIves/github-pages-deploy-action@v4.6.9
-        with:
-          branch: gh-pages
-          folder: output
-          clean: ${{ inputs.clean }}
+      - name: Workflow removed
+        run: |-
+          echo "This workflow has been removed."
+          echo "Please see how to use the updated shared workflows at https://github.com/esphome/esphome-project-template/tree/main/.github/workflows"
+          exit 1


### PR DESCRIPTION
This flow has been replaced by a combination of the `build.yml` and `upload-to-gh-release.yml` workflows