### PR TITLE
Bump esphome-build-action to 5.0.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,7 +84,7 @@ jobs:
         run: |
           sed -i "s/version: dev/version: ${{ needs.prepare.outputs.version }}/g" ${{ matrix.file }}
       - name: Build Firmware
-        uses: esphome/build-action@v4.0.4
+        uses: esphome/build-action@v5.0.0
         id: esphome-build
         with:
           yaml-file: ${{ matrix.file }}


### PR DESCRIPTION
https://github.com/esphome/build-action/releases/tag/v5.0.0

This will change the `name` in `manifest.json` files to use the `project` -> `name` if specified before falling back to `friendly_name` then `name`