### PR TITLE
Add optional build caching

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,11 @@ on:
         required: false
         type: string
         default: ""
+      cache:
+        description: Cache build directory
+        required: false
+        type: boolean
+        default: false
 
     outputs:
       version:
@@ -80,6 +85,23 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4.2.2
+      - if: ${{ inputs.cache == true || inputs.cache == 'true' }}
+        id: data-dir
+        shell: bash
+        run: |
+          data_dir=$(dirname ${{ matrix.file }})/.esphome
+          echo "data_dir=$data_dir" >> $GITHUB_OUTPUT
+      - if: ${{ inputs.cache == true || inputs.cache == 'true' }}
+        name: Restore build cache directory
+        id: cache-build-restore
+        uses: actions/cache/restore@v4.2.3
+        with:
+          path: |
+            ~/.esphome
+            ~/.platformio
+            ${{ steps.data-dir.outputs.data_dir }}/build
+            ${{ steps.data-dir.outputs.data_dir }}/storage
+          key: ${{ runner.os }}-esphome-${{ matrix.file }}-${{ inputs.esphome-version }}-build
       - name: Replace project version
         run: |
           sed -i "s/version: dev/version: ${{ needs.prepare.outputs.version }}/g" ${{ matrix.file }}
@@ -92,6 +114,17 @@ jobs:
           complete-manifest: true
           release-summary: ${{ inputs.release-summary }}
           release-url: ${{ inputs.release-url }}
+      - if: ${{ inputs.cache == true || inputs.cache == 'true' }}
+        name: Save build cache directory
+        id: cache-build-save
+        uses: actions/cache/save@v4.2.3
+        with:
+          path: |
+            ~/.esphome
+            ~/.platformio
+            ${{ steps.data-dir.outputs.data_dir }}/build
+            ${{ steps.data-dir.outputs.data_dir }}/storage
+          key: ${{ steps.cache-build-restore.outputs.cache-primary-key }}
       - name: Move files for versioning
         run: |
           mkdir -p output/${{ needs.prepare.outputs.version }}


### PR DESCRIPTION
This sped up bigger builds (20-50 devices) by 50-75%, though it's mostly anecdotal, hard to summarize github action build times AFAIK