### PR TITLE
Revert "Bump actions/download-artifact from 4.3.0 to 5.0.0"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -112,7 +112,7 @@ jobs:
     if: inputs.combined-name != ''
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v5.0.0
+        uses: actions/download-artifact@v4.3.0
         with:
           path: files
           pattern: ${{ needs.prepare.outputs.artifact-prefix }}-*

--- a/.github/workflows/promote-r2.yml
+++ b/.github/workflows/promote-r2.yml
@@ -29,7 +29,7 @@ jobs:
     environment: ${{ inputs.channel }}
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v5.0.0
+        uses: actions/download-artifact@v4.3.0
         with:
           path: files
 

--- a/.github/workflows/upload-to-gh-release.yml
+++ b/.github/workflows/upload-to-gh-release.yml
@@ -16,7 +16,7 @@ jobs:
       contents: write
     steps:
       - name: Download Artifact
-        uses: actions/download-artifact@v5.0.0
+        uses: actions/download-artifact@v4.3.0
         with:
           path: files
 

--- a/.github/workflows/upload-to-r2.yml
+++ b/.github/workflows/upload-to-r2.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v5.0.0
+        uses: actions/download-artifact@v4.3.0
         with:
           path: files
 


### PR DESCRIPTION
Reverts esphome/workflows#128

There is an undocumented breaking change to the output folder structure when there is only a single artifact downloaded: https://github.com/actions/download-artifact/issues/419