### PR TITLE
feat: ability to change release tag

### DIFF
--- a/.github/workflows/upload-to-gh-release.yml
+++ b/.github/workflows/upload-to-gh-release.yml
@@ -7,6 +7,10 @@ on:
         description: Version of the release
         required: true
         type: string
+      tag:
+        description: Tag of the release
+        required: false
+        type: string
 
 jobs:
   upload:
@@ -55,4 +59,4 @@ jobs:
         uses: softprops/action-gh-release@6cbd405e2c4e67a21c47fa9e383d020e4e28b836 # v2.3.3
         with:
           files: output/*
-          tag_name: ${{ inputs.version }}
+          tag_name: ${{ inputs.tag != '' && inputs.tag || inputs.version }}


### PR DESCRIPTION
can be useful when user is running custom changelog generator with fixed tag name

gracefully fallbacks to version as tag_name if input.tag not specified