### PR TITLE
Fix duplicate draft releases in upload-to-gh-release

### DIFF
--- a/.github/workflows/upload-to-gh-release.yml
+++ b/.github/workflows/upload-to-gh-release.yml
@@ -63,6 +63,12 @@ jobs:
           VERSION: ${{ inputs.version }}
           DRAFT: ${{ inputs.draft }}
         run: |-
+          shopt -s nullglob
+          files=(output/*)
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "::error::No files found in output/ to upload."
+            exit 1
+          fi
           # gh release view/upload cannot resolve draft releases by tag (the tag
           # does not exist until publish), so resolve the release id via the API,
           # which lists drafts too.
@@ -75,19 +81,20 @@ jobs:
             if [ "$DRAFT" = "true" ]; then
               draft_flag=(--draft)
             fi
-            gh release create "$VERSION" output/* --title "$VERSION" "${draft_flag[@]}"
+            gh release create "$VERSION" "${files[@]}" --title "$VERSION" "${draft_flag[@]}"
           else
             if ! assets=$(gh api "repos/$GH_REPO/releases/$release_id/assets" --paginate --jq '.[] | "\(.id)\t\(.name)"'); then
               echo "::error::Failed to list assets for release $release_id."
               exit 1
             fi
-            for file in output/*; do
+            for file in "${files[@]}"; do
               name=$(basename "$file")
-              asset_id=$(awk -F'\t' -v name="$name" '$2 == name {print $1}' <<< "$assets")
+              asset_id=$(awk -F'\t' -v name="$name" '$2 == name {print $1; exit}' <<< "$assets")
               if [ -n "$asset_id" ]; then
                 gh api --method DELETE "repos/$GH_REPO/releases/assets/$asset_id"
               fi
               gh api --method POST \
+                --header "Content-Type: application/octet-stream" \
                 "https://uploads.github.com/repos/$GH_REPO/releases/$release_id/assets?name=$name" \
                 --input "$file" > /dev/null
             done

--- a/.github/workflows/upload-to-gh-release.yml
+++ b/.github/workflows/upload-to-gh-release.yml
@@ -63,12 +63,32 @@ jobs:
           VERSION: ${{ inputs.version }}
           DRAFT: ${{ inputs.draft }}
         run: |-
-          if gh release view "$VERSION" >/dev/null 2>&1; then
-            gh release upload "$VERSION" output/* --clobber
-          else
+          # gh release view/upload cannot resolve draft releases by tag (the tag
+          # does not exist until publish), so resolve the release id via the API,
+          # which lists drafts too.
+          if ! release_id=$(gh api "repos/$GH_REPO/releases" --paginate --jq '[.[] | select(.tag_name == $ENV.VERSION)] | first | .id // empty'); then
+            echo "::error::Failed to list releases for $GH_REPO."
+            exit 1
+          fi
+          if [ -z "$release_id" ]; then
             draft_flag=()
             if [ "$DRAFT" = "true" ]; then
               draft_flag=(--draft)
             fi
             gh release create "$VERSION" output/* --title "$VERSION" "${draft_flag[@]}"
+          else
+            if ! assets=$(gh api "repos/$GH_REPO/releases/$release_id/assets" --paginate --jq '.[] | "\(.id)\t\(.name)"'); then
+              echo "::error::Failed to list assets for release $release_id."
+              exit 1
+            fi
+            for file in output/*; do
+              name=$(basename "$file")
+              asset_id=$(awk -F'\t' -v name="$name" '$2 == name {print $1}' <<< "$assets")
+              if [ -n "$asset_id" ]; then
+                gh api --method DELETE "repos/$GH_REPO/releases/assets/$asset_id"
+              fi
+              gh api --method POST \
+                "https://uploads.github.com/repos/$GH_REPO/releases/$release_id/assets?name=$name" \
+                --input "$file" > /dev/null
+            done
           fi


### PR DESCRIPTION
## Summary

When called with `draft: true`, the upload step used `gh release view "$VERSION"` to decide between uploading and creating. `gh release view` cannot reliably resolve draft releases by tag — a draft's tag doesn't exist until publish — so every run fell into the `else` branch and created a brand-new draft instead of attaching assets to the existing release-drafter-managed draft (e.g. esphome/infrared-proxies runs 29539487348 and 29540064934 each created an extra `26.7.1` draft).

The step now resolves the release id explicitly via `gh api repos/$GH_REPO/releases` (which includes drafts), uploads each asset by release id through the uploads API — deleting any existing same-named asset first to keep the old `--clobber` behavior — and only falls back to `gh release create` when no release with that tag exists at all. Published releases resolve through the same id lookup, so the release.yml → publish.yml flow is unchanged. A failure to list releases now hard-fails the step instead of silently minting a stray draft.