### PR TITLE
Safely bump artifact actions and add end-to-end CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,15 +92,30 @@ jobs:
           complete-manifest: true
           release-summary: ${{ inputs.release-summary }}
           release-url: ${{ inputs.release-url }}
+      - name: Determine artifact name
+        id: artifact
+        run: |
+          if [ -n "${{ inputs.combined-name }}" ]; then
+            name="${{ needs.prepare.outputs.artifact-prefix }}-${{ steps.esphome-build.outputs.name }}"
+          else
+            name="${{ steps.esphome-build.outputs.original-name }}"
+          fi
+          echo name=$name >> $GITHUB_OUTPUT
+      # The artifact name is embedded as the top-level directory of the
+      # artifact so that downloading with merge-multiple: true always yields
+      # <path>/<artifact-name>/<version>/. download-artifact v5+ no longer
+      # creates the per-artifact directory when a download matches only a
+      # single artifact (actions/download-artifact#419).
       - name: Move files for versioning
         run: |
-          mkdir -p output/${{ needs.prepare.outputs.version }}
-          mv ${{ steps.esphome-build.outputs.name }}/* output/${{ needs.prepare.outputs.version }}/
+          name="${{ steps.artifact.outputs.name }}"
+          version="${{ needs.prepare.outputs.version }}"
+          mkdir -p "output/$name/$version"
+          mv ${{ steps.esphome-build.outputs.name }}/* "output/$name/$version/"
       - name: Upload artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          # yamllint disable-line rule:line-length
-          name: ${{ inputs.combined-name != '' && format('{0}-{1}', needs.prepare.outputs.artifact-prefix, steps.esphome-build.outputs.name) || steps.esphome-build.outputs.original-name }}
+          name: ${{ steps.artifact.outputs.name }}
           path: output
 
   combine:
@@ -112,10 +127,14 @@ jobs:
     if: inputs.combined-name != ''
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: files
           pattern: ${{ needs.prepare.outputs.artifact-prefix }}-*
+          # Each artifact embeds its name as its top-level directory, so
+          # merging yields files/<artifact-name>/<version>/ regardless of
+          # how many artifacts match the pattern.
+          merge-multiple: true
 
       - name: Get artifact names
         id: artifacts
@@ -133,21 +152,22 @@ jobs:
       - name: Combine all parts into a single manifest
         run: |
           version="${{ needs.prepare.outputs.version }}"
-          mkdir -p "output/$version"
+          combined="${{ inputs.combined-name }}"
+          mkdir -p "output/$combined/$version"
           pushd files
           for device in *; do
             pushd $device
             pushd $version
-            cp * "../../../output/$version/"
+            cp * "../../../output/$combined/$version/"
             popd
             popd
           done
           popd
           jq -s '(.[0] | del(.builds)) + {"builds": (reduce .[].builds as $b ([]; . + $b))}' \
-            files/*/$version/manifest.json > output/$version/manifest.json
+            files/*/$version/manifest.json > "output/$combined/$version/manifest.json"
 
       - name: Upload artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ inputs.combined-name }}
           path: output

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,233 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: yamllint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Run yamllint
+        run: pipx run yamllint .
+
+  # The build scenarios call the reusable workflows from this checkout, so a
+  # PR exercises its own changes end-to-end without pointing a consumer
+  # repository at a branch ref.
+  build-single:
+    name: Build (single artifact)
+    uses: ./.github/workflows/build.yml
+    with:
+      files: tests/ci-single.yaml
+      release-version: ci-${{ github.run_id }}
+
+  build-combined:
+    name: Build (combined artifact)
+    uses: ./.github/workflows/build.yml
+    with:
+      files: |
+        tests/ci-combined-a.yaml
+        tests/ci-combined-b.yaml
+      combined-name: ci-combined
+      release-version: ci-${{ github.run_id }}
+
+  # Exercises the combine job's pattern download matching a single artifact —
+  # the case where download-artifact v5+ drops the per-artifact directory
+  # (actions/download-artifact#419).
+  build-combined-single:
+    name: Build (combined artifact, single file)
+    uses: ./.github/workflows/build.yml
+    with:
+      files: tests/ci-combined-single.yaml
+      combined-name: ci-combined-single
+      release-version: ci-${{ github.run_id }}
+
+  verify-artifacts:
+    name: Verify artifact layout
+    runs-on: ubuntu-latest
+    needs:
+      - build-single
+      - build-combined
+      - build-combined-single
+    steps:
+      - name: Download all artifacts (as the upload workflows do)
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: files
+          merge-multiple: true
+
+      - name: Download one artifact via pattern (single match)
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: single
+          pattern: ci-single
+          merge-multiple: true
+
+      - name: Tree
+        run: tree
+
+      - name: Verify layout
+        run: |
+          version="ci-${{ github.run_id }}"
+          fail=0
+
+          for name in ci-single ci-combined ci-combined-single; do
+            if [ ! -f "files/$name/$version/manifest.json" ]; then
+              echo "::error::Missing files/$name/$version/manifest.json"
+              fail=1
+            fi
+          done
+
+          for entry in files/*; do
+            case "$(basename "$entry")" in
+              ci-single|ci-combined|ci-combined-single) ;;
+              *)
+                echo "::error::Unexpected top-level entry: $entry"
+                fail=1
+                ;;
+            esac
+          done
+
+          # A download matching a single artifact must still produce the
+          # per-artifact directory (actions/download-artifact#419).
+          if [ ! -f "single/ci-single/$version/manifest.json" ]; then
+            echo "::error::Single-match download lost the artifact directory"
+            fail=1
+          fi
+
+          if ! builds=$(jq '.builds | length' "files/ci-combined/$version/manifest.json"); then
+            echo "::error::Failed to read the ci-combined manifest"
+            fail=1
+          elif [ "$builds" -ne 2 ]; then
+            echo "::error::ci-combined manifest has $builds builds, expected 2"
+            fail=1
+          fi
+
+          if ! builds=$(jq '.builds | length' "files/ci-combined-single/$version/manifest.json"); then
+            echo "::error::Failed to read the ci-combined-single manifest"
+            fail=1
+          elif [ "$builds" -ne 1 ]; then
+            echo "::error::ci-combined-single manifest has $builds builds, expected 1"
+            fail=1
+          fi
+
+          shopt -s nullglob
+          for name in ci-single ci-combined ci-combined-single; do
+            bins=("files/$name/$version/"*.bin)
+            if [ "${#bins[@]}" -eq 0 ]; then
+              echo "::error::No firmware binaries in files/$name/$version/"
+              fail=1
+            fi
+          done
+
+          exit $fail
+
+  # End-to-end test of upload-to-gh-release.yml against a draft release.
+  # Skipped for fork PRs, which get a read-only token.
+  test-gh-release:
+    name: Upload to draft GitHub release
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    needs:
+      - build-single
+      - build-combined
+      - build-combined-single
+    permissions:
+      contents: write
+    uses: ./.github/workflows/upload-to-gh-release.yml
+    with:
+      version: ci-${{ github.run_id }}
+      draft: true
+
+  verify-gh-release:
+    name: Verify draft release assets
+    runs-on: ubuntu-latest
+    needs:
+      - test-gh-release
+    permissions:
+      # Write access so the release listing includes drafts.
+      contents: write
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: files
+          merge-multiple: true
+
+      - name: Verify release assets match the built artifacts
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          VERSION: ci-${{ github.run_id }}
+        run: |
+          shopt -s nullglob
+          expected=$(mktemp)
+          for device_dir in files/*; do
+            device=$(basename "$device_dir")
+            echo "$device.manifest.json" >> "$expected"
+            for bin in "$device_dir/$VERSION/"*.{bin,elf}; do
+              b=$(basename "$bin")
+              printf '%s\n%s.md5\n%s.sha256\n' "$b" "$b" "$b" >> "$expected"
+            done
+          done
+          sort -u "$expected" -o "$expected"
+
+          if ! releases=$(gh api "repos/$GH_REPO/releases?per_page=100"); then
+            echo "::error::Failed to list releases."
+            exit 1
+          fi
+          actual=$(jq -r --arg v "$VERSION" \
+            '.[] | select(.tag_name == $v and .draft) | .assets[].name' \
+            <<< "$releases" | sort -u)
+          if [ -z "$actual" ]; then
+            echo "::error::Draft release $VERSION not found or has no assets."
+            exit 1
+          fi
+
+          if ! diff "$expected" <(printf '%s\n' "$actual"); then
+            echo "::error::Draft release assets do not match the artifacts."
+            exit 1
+          fi
+
+  cleanup-gh-release:
+    name: Delete draft release
+    runs-on: ubuntu-latest
+    # Clean up even when verification fails, but not when the upload was
+    # skipped (fork PR) or never ran.
+    if: always() && (needs.test-gh-release.result == 'success' || needs.test-gh-release.result == 'failure')
+    needs:
+      - test-gh-release
+      - verify-gh-release
+    permissions:
+      contents: write
+    steps:
+      - name: Delete CI draft release(s)
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          VERSION: ci-${{ github.run_id }}
+        run: |
+          if ! releases=$(gh api "repos/$GH_REPO/releases?per_page=100"); then
+            echo "::error::Failed to list releases."
+            exit 1
+          fi
+          ids=$(jq -r --arg v "$VERSION" \
+            '.[] | select(.tag_name == $v and .draft) | .id' <<< "$releases")
+          if [ -z "$ids" ]; then
+            echo "No draft release to clean up."
+            exit 0
+          fi
+          mapfile -t id_arr <<< "$ids"
+          for id in "${id_arr[@]}"; do
+            gh api -X DELETE "repos/$GH_REPO/releases/$id"
+            echo "Deleted draft release $id"
+          done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,10 @@ on:
       - main
   workflow_dispatch:
 
+# Default for all jobs; the release jobs override this with contents: write.
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/promote-r2.yml
+++ b/.github/workflows/promote-r2.yml
@@ -29,9 +29,15 @@ jobs:
     environment: ${{ inputs.channel }}
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: files
+          # Each artifact built by build.yml embeds its name as its top-level
+          # directory, so merging yields files/<artifact-name>/<version>/
+          # regardless of how many artifacts the run has. Without merging,
+          # download-artifact v5+ drops the per-artifact directory when the
+          # run has only a single artifact (actions/download-artifact#419).
+          merge-multiple: true
 
       - name: Build ${{ inputs.manifest-filename }}
         run: |

--- a/.github/workflows/upload-to-gh-release.yml
+++ b/.github/workflows/upload-to-gh-release.yml
@@ -71,7 +71,8 @@ jobs:
           # gh release view/upload cannot resolve draft releases by tag (the tag
           # does not exist until publish), so resolve the release id via the API,
           # which lists drafts too.
-          if ! release_id=$(gh api "repos/$GH_REPO/releases" --paginate --jq '[.[] | select(.tag_name == $ENV.VERSION)] | first | .id // empty'); then
+          if ! release_id=$(gh api "repos/$GH_REPO/releases" --paginate \
+              --jq '[.[] | select(.tag_name == $ENV.VERSION)] | first | .id // empty'); then
             echo "::error::Failed to list releases for $GH_REPO."
             exit 1
           fi
@@ -82,7 +83,8 @@ jobs:
             fi
             gh release create "$VERSION" "${files[@]}" --title "$VERSION" "${draft_flag[@]}"
           else
-            if ! assets=$(gh api "repos/$GH_REPO/releases/$release_id/assets" --paginate --jq '.[] | "\(.id)\t\(.name)"'); then
+            if ! assets=$(gh api "repos/$GH_REPO/releases/$release_id/assets" \
+                --paginate --jq '.[] | "\(.id)\t\(.name)"'); then
               echo "::error::Failed to list assets for release $release_id."
               exit 1
             fi

--- a/.github/workflows/upload-to-gh-release.yml
+++ b/.github/workflows/upload-to-gh-release.yml
@@ -21,9 +21,15 @@ jobs:
       contents: write
     steps:
       - name: Download Artifact
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: files
+          # Each artifact built by build.yml embeds its name as its top-level
+          # directory, so merging yields files/<artifact-name>/<version>/
+          # regardless of how many artifacts the run has. Without merging,
+          # download-artifact v5+ drops the per-artifact directory when the
+          # run has only a single artifact (actions/download-artifact#419).
+          merge-multiple: true
 
       - name: Tree
         run: |-
@@ -37,21 +43,14 @@ jobs:
           pushd files
           for device in *; do
             pushd $device
-            if [ "$device" != "$version" ]; then
-              pushd $version
-              output_path="../../../output/"
-            else
-              output_path="../../output/"
-            fi
-            cp manifest.json "${output_path}$device.manifest.json"
+            pushd $version
+            cp manifest.json "../../../output/$device.manifest.json"
             for bin in *.{bin,elf}; do
-              md5sum $bin | head -c 32 > "${output_path}$bin.md5"
-              sha256sum $bin | head -c 64 > "${output_path}$bin.sha256"
-              cp $bin "$output_path"
+              md5sum $bin | head -c 32 > "../../../output/$bin.md5"
+              sha256sum $bin | head -c 64 > "../../../output/$bin.sha256"
+              cp $bin ../../../output/
             done
-            if [ "$device" != "$version" ]; then
-              popd
-            fi
+            popd
             popd
           done
           popd

--- a/.github/workflows/upload-to-r2.yml
+++ b/.github/workflows/upload-to-r2.yml
@@ -17,9 +17,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: files
+          # Each artifact built by build.yml embeds its name as its top-level
+          # directory, so merging yields files/<artifact-name>/<version>/
+          # regardless of how many artifacts the run has. Without merging,
+          # download-artifact v5+ drops the per-artifact directory when the
+          # run has only a single artifact (actions/download-artifact#419).
+          merge-multiple: true
 
       - run: tree
 

--- a/README.md
+++ b/README.md
@@ -15,3 +15,13 @@ This repository contains workflows to be used by other repositories.
 ## Usage
 
 See https://github.com/esphome/esphome-project-template for usage of these workflows.
+
+## CI
+
+Pull requests run `ci.yml`, which calls the reusable workflows from the PR's
+own checkout (`uses: ./.github/workflows/...`) against the ESPHome configs in
+`tests/`. It builds single-artifact, combined, and combined-single-file
+scenarios, verifies the downloaded artifact layout, and exercises
+`upload-to-gh-release.yml` against a draft release that is deleted afterwards.
+The R2 workflows are not run end-to-end (they need Cloudflare secrets), but
+they consume artifacts the same way the verified workflows do.

--- a/tests/ci-combined-a.yaml
+++ b/tests/ci-combined-a.yaml
@@ -1,0 +1,23 @@
+esphome:
+  name: ci-combined-a
+  friendly_name: CI Combined A
+  project:
+    name: esphome.workflows-ci
+    version: dev
+
+esp8266:
+  board: esp01_1m
+
+logger:
+
+api:
+
+ota:
+  - platform: esphome
+
+improv_serial:
+
+wifi:
+  ap: {}
+
+captive_portal:

--- a/tests/ci-combined-b.yaml
+++ b/tests/ci-combined-b.yaml
@@ -1,0 +1,23 @@
+esphome:
+  name: ci-combined-b
+  friendly_name: CI Combined B
+  project:
+    name: esphome.workflows-ci
+    version: dev
+
+esp8266:
+  board: esp01_1m
+
+logger:
+
+api:
+
+ota:
+  - platform: esphome
+
+improv_serial:
+
+wifi:
+  ap: {}
+
+captive_portal:

--- a/tests/ci-combined-single.yaml
+++ b/tests/ci-combined-single.yaml
@@ -1,0 +1,23 @@
+esphome:
+  name: ci-combined-single
+  friendly_name: CI Combined Single
+  project:
+    name: esphome.workflows-ci
+    version: dev
+
+esp8266:
+  board: esp01_1m
+
+logger:
+
+api:
+
+ota:
+  - platform: esphome
+
+improv_serial:
+
+wifi:
+  ap: {}
+
+captive_portal:

--- a/tests/ci-single.yaml
+++ b/tests/ci-single.yaml
@@ -1,0 +1,23 @@
+esphome:
+  name: ci-single
+  friendly_name: CI Single
+  project:
+    name: esphome.workflows-ci
+    version: dev
+
+esp8266:
+  board: esp01_1m
+
+logger:
+
+api:
+
+ota:
+  - platform: esphome
+
+improv_serial:
+
+wifi:
+  ap: {}
+
+captive_portal:


### PR DESCRIPTION
## Summary

Bumps `actions/upload-artifact` 4.6.2 → 7.0.1 and `actions/download-artifact` 4.3.0 → 8.0.1, with the workflow changes needed to make the bump safe, and adds CI so future workflow changes are verified in-repo.

## Why the previous bump broke

`download-artifact` v5+ extracts a download directly into `path` (no `<artifact-name>/` subdirectory) whenever it matches exactly **one** artifact — including "download all" and `pattern:` downloads. That flattened the layout for any consumer whose run produced a single artifact (the normal case for project-template users with `combined-name`), which is why #128 had to be reverted in #133. Upstream declined to restore the v4 behaviour ([actions/download-artifact#419](https://github.com/actions/download-artifact/issues/419)), so a plain re-bump (#155/#157) would break consumers again.

## The fix

`build.yml` now embeds the artifact name as the top-level directory inside each artifact (`<artifact-name>/<version>/...`), and every download step uses `merge-multiple: true`. The extracted layout is therefore `files/<artifact-name>/<version>/` no matter how many artifacts are downloaded, with no extra token permissions required. Artifact names stay intact where they matter: R2 destination paths, `<name>.manifest.json` release assets, and the combine job's delete-artifact list. The single-artifact workaround from #130 is now obsolete and removed. Since consumers pin `build.yml` and the upload workflows to the same release ref, upload and download sides always move in lockstep within a run.

## CI

New `ci.yml` calls the reusable workflows from the PR's own checkout (`uses: ./.github/workflows/...`) against fixture configs in `tests/`, so changes like this one (and future dependabot bumps) are exercised end-to-end without pointing a consumer repo at a branch ref:

- Builds three scenarios: single artifact, combined (two files), and combined from a single file — the last one hits the exact pattern-matches-one-artifact flatten case that caused the 2025 breakage.
- Verifies the downloaded artifact layout both via download-all and via a single-match pattern download.
- Runs `upload-to-gh-release.yml` for real against a draft release, checks the assets exactly match what the artifacts should produce, and deletes the draft afterwards (skipped on fork PRs, which get a read-only token).
- Runs yamllint (the `.yamllint` config was previously unenforced).

The R2 workflows are not run end-to-end (they need Cloudflare secrets), but they consume artifacts identically to the verified download path.