### PR TITLE
Add reusable draft-release pipeline workflows

### DIFF
--- a/.github/workflows/build-to-draft-release.yml
+++ b/.github/workflows/build-to-draft-release.yml
@@ -1,0 +1,237 @@
+name: Build to Draft Release
+# Builds firmware and, when triggered by a successful Release Drafter run,
+# replaces the draft release's assets with the fresh build. Callers trigger
+# it on pull_request / workflow_dispatch (build only) and on workflow_run of
+# their Release Drafter workflow (build and upload to the draft); the event
+# gating lives in here, so callers stay a single `uses:` job.
+
+on:
+  workflow_call:
+    inputs:
+      esphome-version:
+        description: Version of ESPHome to build with
+        required: true
+        type: string
+      files:
+        description: >-
+          Newline separated list of files to build. Leave empty to build
+          every *.factory.yaml in the calling repository.
+        required: false
+        type: string
+        default: ""
+
+jobs:
+  discover-files:
+    name: Discover Factory Configs
+    # Skip the entire pipeline if the Release Drafter run that triggered us failed.
+    if: >-
+      github.event_name != 'workflow_run' ||
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      files: ${{ steps.find.outputs.files }}
+    steps:
+      - name: Checkout code
+        if: inputs.files == ''
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Find factory configs
+        id: find
+        env:
+          INPUT_FILES: ${{ inputs.files }}
+        run: |
+          set -euo pipefail
+          files="${INPUT_FILES}"
+          if [[ -z "${files}" ]]; then
+            # By convention every device ships a <device>/<device>.factory.yaml;
+            # anything matching *.factory.yaml outside hidden directories is
+            # built. Prune dot-directories (.git, .github) rather than just
+            # filtering them from the results, so find never descends into them.
+            files=$(find . -path '*/.*' -prune -o -name '*.factory.yaml' -print | sed 's|^\./||' | sort)
+          fi
+          if [[ -z "${files}" ]]; then
+            echo "::error::No *.factory.yaml files found"
+            exit 1
+          fi
+          echo "Files to build:"
+          echo "${files}"
+          {
+            echo "files<<FACTORY_FILES_EOF"
+            echo "${files}"
+            echo "FACTORY_FILES_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+  determine-version:
+    name: Determine Version
+    # Skip the entire pipeline if the Release Drafter run that triggered us failed.
+    if: >-
+      github.event_name != 'workflow_run' ||
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    # No permissions block on purpose: reading the draft release needs
+    # contents: write (drafts are only visible to tokens with push access),
+    # which this job inherits from the caller on workflow_run events.
+    # Requesting it here would fail the job on pull requests from forks,
+    # where the token cannot be elevated — and on those events this job
+    # never touches the API anyway.
+    outputs:
+      version: ${{ steps.info.outputs.version }}
+      summary: ${{ steps.info.outputs.summary }}
+      url: ${{ steps.info.outputs.url }}
+    steps:
+      - name: Look up draft release info
+        id: info
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          set -euo pipefail
+          tag=""
+          url=""
+          body=""
+          if [[ "${EVENT_NAME}" == "workflow_run" ]]; then
+            if ! releases=$(gh api "repos/${GH_REPO}/releases?per_page=100"); then
+              echo "::error::Failed to list releases"
+              exit 1
+            fi
+            # Ignore drafts whose tag was reset to an untagged-* placeholder
+            # (a stray PATCH without tag_name causes this) — building against
+            # one would bake the placeholder into the firmware as its version.
+            release_json=$(jq \
+              '[.[] | select(.draft == true and (.tag_name | startswith("untagged-") | not))] | first' \
+              <<< "${releases}")
+            if [[ -z "${release_json}" || "${release_json}" == "null" ]]; then
+              echo "::error::No draft release found"
+              exit 1
+            fi
+            tag=$(jq -r '.tag_name' <<< "${release_json}")
+            url=$(jq -r '.html_url' <<< "${release_json}")
+            # Strip the ASSETS_PENDING caution block from the draft body before
+            # baking it into the firmware as release-summary; the warning is
+            # only meant for the maintainer viewing the draft on GitHub.
+            body=$(jq -r '.body' <<< "${release_json}" \
+              | sed '/^> \[!CAUTION\]/,/<!-- ASSETS_PENDING -->/d' \
+              | sed 's/<!-- ASSETS_PENDING -->//g' \
+              | sed '/./,$!d')
+          fi
+          echo "version=${tag}" >> "$GITHUB_OUTPUT"
+          echo "url=${url}" >> "$GITHUB_OUTPUT"
+          {
+            echo "summary<<RELEASE_SUMMARY_EOF"
+            echo "${body}"
+            echo "RELEASE_SUMMARY_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+  build-firmware:
+    name: Build Firmware
+    needs:
+      - discover-files
+      - determine-version
+    uses: ./.github/workflows/build.yml
+    with:
+      files: ${{ needs.discover-files.outputs.files }}
+      esphome-version: ${{ inputs.esphome-version }}
+      release-summary: ${{ needs.determine-version.outputs.summary }}
+      release-url: ${{ needs.determine-version.outputs.url }}
+      release-version: ${{ needs.determine-version.outputs.version }}
+
+  clean-draft-assets:
+    name: Clean Draft Release Assets
+    # Delete any pre-existing assets so renamed files (e.g. when the version
+    # bumps from .1 to .2) don't linger alongside the new ones. Gated on
+    # build success so a failed build doesn't leave the draft release empty.
+    if: github.event_name == 'workflow_run'
+    needs:
+      - build-firmware
+      - determine-version
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Delete existing assets from draft release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ needs.determine-version.outputs.version }}
+        run: |
+          set -euo pipefail
+          if ! releases=$(gh api "repos/${GH_REPO}/releases?per_page=100"); then
+            echo "::error::Failed to list releases"
+            exit 1
+          fi
+          release=$(jq --arg tag "${TAG}" \
+            '[.[] | select(.tag_name == $tag and .draft == true)] | first' <<< "${releases}")
+          if [[ -z "${release}" || "${release}" == "null" ]]; then
+            echo "Draft release ${TAG} not found; nothing to clean"
+            exit 0
+          fi
+          release_id=$(jq -r '.id' <<< "${release}")
+          if ! asset_ids=$(gh api "repos/${GH_REPO}/releases/${release_id}/assets" --paginate --jq '.[].id'); then
+            echo "::error::Failed to list draft release assets"
+            exit 1
+          fi
+          for id in ${asset_ids}; do
+            echo "Deleting asset ${id}"
+            gh api "repos/${GH_REPO}/releases/assets/${id}" --method DELETE --silent
+          done
+
+  upload-to-draft-release:
+    name: Upload to Draft Release
+    if: github.event_name == 'workflow_run'
+    needs:
+      - build-firmware
+      - determine-version
+      - clean-draft-assets
+    permissions:
+      contents: write
+    uses: ./.github/workflows/upload-to-gh-release.yml
+    with:
+      version: ${{ needs.determine-version.outputs.version }}
+      draft: true
+
+  remove-pending-warning:
+    name: Remove Pending Warning
+    if: github.event_name == 'workflow_run'
+    needs:
+      - upload-to-draft-release
+      - determine-version
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Remove ASSETS_PENDING warning from draft release body
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ needs.determine-version.outputs.version }}
+        run: |
+          set -euo pipefail
+          if ! releases=$(gh api "repos/${GH_REPO}/releases?per_page=100"); then
+            echo "::error::Failed to list releases"
+            exit 1
+          fi
+          release=$(jq --arg tag "${TAG}" \
+            '[.[] | select(.tag_name == $tag and .draft == true)] | first' <<< "${releases}")
+          if [[ -z "${release}" || "${release}" == "null" ]]; then
+            echo "Draft release ${TAG} not found; nothing to clean up"
+            exit 0
+          fi
+          release_id=$(jq -r '.id' <<< "${release}")
+          body=$(jq -r '.body' <<< "${release}")
+          new_body=$(echo "${body}" \
+            | sed '/^> \[!CAUTION\]/,/<!-- ASSETS_PENDING -->/d' \
+            | sed 's/<!-- ASSETS_PENDING -->//g' \
+            | sed '/./,$!d')
+          if [[ "${new_body}" != "${body}" ]]; then
+            # tag_name and name must be re-sent: updating a draft release
+            # without them resets its tag to an untagged-* placeholder.
+            gh api "repos/${GH_REPO}/releases/${release_id}" \
+              --method PATCH \
+              --field "body=${new_body}" \
+              --field "tag_name=${TAG}" \
+              --field "name=${TAG}" \
+              --field "draft=true" \
+              --silent
+          fi

--- a/.github/workflows/build-to-draft-release.yml
+++ b/.github/workflows/build-to-draft-release.yml
@@ -69,12 +69,12 @@ jobs:
       github.event_name != 'workflow_run' ||
       github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
-    # No permissions block on purpose: reading the draft release needs
-    # contents: write (drafts are only visible to tokens with push access),
-    # which this job inherits from the caller on workflow_run events.
-    # Requesting it here would fail the job on pull requests from forks,
-    # where the token cannot be elevated — and on those events this job
-    # never touches the API anyway.
+    # No permissions block on purpose: this job inherits the caller's grant.
+    # Reading the draft release needs contents: write (drafts are only
+    # visible to tokens with push access), which the caller must grant on
+    # every event anyway: GitHub validates each nested job's requested
+    # permissions against the caller's grant when the workflow is called,
+    # even for jobs that end up skipped (see clean-draft-assets below).
     outputs:
       version: ${{ steps.info.outputs.version }}
       summary: ${{ steps.info.outputs.summary }}

--- a/.github/workflows/ci-draft-release.yml
+++ b/.github/workflows/ci-draft-release.yml
@@ -1,0 +1,76 @@
+name: CI Draft Release
+
+# Smoke-tests build-to-draft-release.yml from the PR's own checkout. This
+# runs as its own workflow (not a job in ci.yml) because ci.yml's
+# test-gh-release job downloads every artifact of its run, and the smoke
+# build's artifact carries a different version directory. Only the
+# pull_request/push path is exercised here: the draft-release jobs are
+# skipped by design (they only run for workflow_run events in consumer
+# repositories, and need a live draft release).
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+# The draft-release jobs inside the called workflow are skipped on these
+# events, so nothing here needs more than read access.
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-to-draft:
+    name: Build to draft release (smoke)
+    uses: ./.github/workflows/build-to-draft-release.yml
+    with:
+      # No files input: exercises the *.factory.yaml auto-discovery, which
+      # finds tests/ci-draft.factory.yaml (the only factory config here).
+      esphome-version: latest
+
+  verify-artifacts:
+    name: Verify artifact layout
+    runs-on: ubuntu-latest
+    needs:
+      - build-to-draft
+    steps:
+      - name: Download all artifacts (as the upload workflows do)
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          path: files
+          merge-multiple: true
+
+      - name: Tree
+        run: tree
+
+      - name: Verify layout
+        run: |
+          fail=0
+
+          # Without a draft release to take a version from, build.yml
+          # generates a dev-<timestamp> version.
+          if ! compgen -G "files/ci-draft/dev-*/manifest.json" > /dev/null; then
+            echo "::error::Missing files/ci-draft/dev-*/manifest.json"
+            fail=1
+          fi
+
+          shopt -s nullglob
+          bins=(files/ci-draft/dev-*/*.bin)
+          if [ "${#bins[@]}" -eq 0 ]; then
+            echo "::error::No firmware binaries in files/ci-draft/dev-*/"
+            fail=1
+          fi
+
+          for entry in files/*; do
+            if [ "$(basename "$entry")" != "ci-draft" ]; then
+              echo "::error::Unexpected top-level entry: $entry"
+              fail=1
+            fi
+          done
+
+          exit $fail

--- a/.github/workflows/ci-draft-release.yml
+++ b/.github/workflows/ci-draft-release.yml
@@ -15,10 +15,13 @@ on:
       - main
   workflow_dispatch:
 
-# The draft-release jobs inside the called workflow are skipped on these
-# events, so nothing here needs more than read access.
+# The called workflow's draft-release jobs are skipped on these events, but
+# GitHub validates every nested job's requested permissions against this
+# grant at call time — even jobs that end up skipped — so contents: write
+# must be granted for the call to be valid at all. This matches what real
+# consumers grant.
 permissions:
-  contents: read
+  contents: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/draft-calver-release.yml
+++ b/.github/workflows/draft-calver-release.yml
@@ -1,0 +1,73 @@
+name: Draft CalVer Release
+# Computes the next CalVer version (YY.M.N) and creates or updates a draft
+# release for it with release-drafter. The release-drafter action reads
+# .github/release-drafter.yml from the calling repository at runtime, so each
+# consumer keeps its own release-notes configuration.
+
+on:
+  workflow_call:
+
+jobs:
+  release-drafter:
+    name: Update draft release
+    runs-on: ubuntu-latest
+    permissions:
+      # contents: write to create/update the draft release (drafts are also
+      # only listed for tokens with push access); pull-requests: read for
+      # release-drafter to build the release notes.
+      contents: write
+      pull-requests: read
+    steps:
+      - name: Calculate calver version
+        id: calver
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          # CalVer scheme: YY.M.N
+          #   YY = year mod 100 (e.g. 2026 -> 26)
+          #   M  = month, no zero padding (e.g. April -> 4)
+          #   N  = sequential release of that month, starting at 1
+          year=$(date -u +%y)
+          month=$(date -u +%-m)
+          prefix="${year}.${month}."
+
+          # The newest 100 releases always include everything tagged in the
+          # current month, so one page is enough to find the highest sequence.
+          if ! releases=$(gh api "repos/${GH_REPO}/releases?per_page=100"); then
+            echo "::error::Failed to list releases"
+            exit 1
+          fi
+
+          # Highest existing tag (draft or published) matching the current YY.M.*
+          latest_seq=$(jq -r --arg prefix "${prefix}" \
+            '[.[] | select(.tag_name | startswith($prefix))
+              | .tag_name | ltrimstr($prefix) | tonumber?] | max // 0' \
+            <<< "${releases}")
+
+          if [[ "${latest_seq}" -eq 0 ]]; then
+            seq=1
+          else
+            # If the existing release at the highest seq is still a draft, reuse it
+            # so subsequent pushes update the same draft. Otherwise start a new one.
+            is_draft=$(jq -r --arg tag "${prefix}${latest_seq}" \
+              '[.[] | select(.tag_name == $tag)] | first | .draft' <<< "${releases}")
+            if [[ "${is_draft}" == "true" ]]; then
+              seq=${latest_seq}
+            else
+              seq=$((latest_seq + 1))
+            fi
+          fi
+
+          version="${prefix}${seq}"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "Calculated calver version: ${version}"
+
+      - uses: release-drafter/release-drafter@4d75298e00d9e34c483e5ff8c68d0ea1c1940c1e # v7.5.1
+        with:
+          version: ${{ steps.calver.outputs.version }}
+          tag: ${{ steps.calver.outputs.version }}
+          name: ${{ steps.calver.outputs.version }}
+        env:
+          GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/publish-draft-release.yml
+++ b/.github/workflows/publish-draft-release.yml
@@ -1,0 +1,185 @@
+name: Publish Draft Release
+# Patches the draft release's *.manifest.json assets with the final release
+# notes, then publishes the draft. This workflow is only to be used within
+# the ESPHome organisation on GitHub: it authenticates with the ESPHome
+# GitHub App via the ESPHOME_GITHUB_APP_CLIENT_ID variable (resolved against
+# the calling repository or its organisation) and the
+# ESPHOME_GITHUB_APP_PRIVATE_KEY secret.
+
+on:
+  workflow_call:
+    inputs:
+      tag:
+        description: Release tag to publish (defaults to the most recent draft)
+        required: false
+        type: string
+        default: ""
+    secrets:
+      ESPHOME_GITHUB_APP_PRIVATE_KEY:
+        description: Private key of the ESPHome GitHub App
+        required: true
+
+jobs:
+  release:
+    name: Patch manifests and publish
+    runs-on: ubuntu-latest
+    # The release environment must exist in the calling repository; it gates
+    # publishing behind any protection rules configured there.
+    environment: release
+    concurrency:
+      group: publish-draft-release-${{ inputs.tag || 'latest-draft' }}
+      cancel-in-progress: false
+    # Every step authenticates with the ESPHome GitHub App token (see the
+    # comment on the first step); the default GITHUB_TOKEN is never used.
+    permissions: {}
+    steps:
+      # We use a GitHub App token (not GITHUB_TOKEN) so that publishing the
+      # release fires a `release: published` event downstream — the default
+      # GITHUB_TOKEN intentionally does not trigger further workflows, which
+      # would leave the publish workflow dormant.
+      - name: Generate a token
+        id: generate-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.ESPHOME_GITHUB_APP_CLIENT_ID }}
+          private-key: ${{ secrets.ESPHOME_GITHUB_APP_PRIVATE_KEY }}
+          # Scope the token to what this job does: read the draft release,
+          # replace its manifest assets and publish it.
+          permission-contents: write
+
+      - name: Resolve draft release
+        id: find
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+          GH_REPO: ${{ github.repository }}
+          INPUT_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          if ! releases=$(gh api "repos/${GH_REPO}/releases?per_page=100"); then
+            echo "::error::Failed to list releases"
+            exit 1
+          fi
+          tag="${INPUT_TAG}"
+          if [[ -z "${tag}" ]]; then
+            # Ignore drafts whose tag was reset to an untagged-* placeholder
+            # (a stray PATCH without tag_name causes this) — publishing one
+            # would create a release under the placeholder tag.
+            tag=$(jq -r \
+              '[.[] | select(.draft == true and (.tag_name | startswith("untagged-") | not))]
+                | first | .tag_name // ""' \
+              <<< "${releases}")
+          fi
+          if [[ -z "${tag}" || "${tag}" == "null" ]]; then
+            echo "::error::No draft release found"
+            exit 1
+          fi
+          release=$(jq --arg tag "${tag}" \
+            '[.[] | select(.tag_name == $tag and .draft == true)] | first' <<< "${releases}")
+          if [[ -z "${release}" || "${release}" == "null" ]]; then
+            echo "::error::Draft release ${tag} not found"
+            exit 1
+          fi
+          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+          echo "release_id=$(jq -r '.id' <<< "${release}")" >> "$GITHUB_OUTPUT"
+          echo "url=$(jq -r '.html_url' <<< "${release}")" >> "$GITHUB_OUTPUT"
+          {
+            echo "body<<RELEASE_BODY_EOF"
+            jq -r '.body' <<< "${release}"
+            echo "RELEASE_BODY_EOF"
+          } >> "$GITHUB_OUTPUT"
+          echo "Resolved draft release: ${tag}"
+
+      - name: Download manifest assets
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+          GH_REPO: ${{ github.repository }}
+          RELEASE_ID: ${{ steps.find.outputs.release_id }}
+        run: |
+          set -euo pipefail
+          mkdir -p assets
+          # Work with the release id resolved above instead of `gh release
+          # download <tag>`: gh resolves draft tags via the singular
+          # releases/tags/{tag} endpoint, which has proven unreliable, while
+          # lookups by id always work.
+          if ! assets=$(gh api "repos/${GH_REPO}/releases/${RELEASE_ID}/assets" \
+            --paginate \
+            --jq '.[] | select(.name | endswith(".manifest.json")) | "\(.id)\t\(.name)"'); then
+            echo "::error::Failed to list draft release assets"
+            exit 1
+          fi
+          if [[ -z "${assets}" ]]; then
+            echo "::error::No *.manifest.json assets found on draft release"
+            exit 1
+          fi
+          while IFS=$'\t' read -r asset_id asset_name; do
+            echo "Downloading ${asset_name}"
+            gh api -H "Accept: application/octet-stream" \
+              "repos/${GH_REPO}/releases/assets/${asset_id}" \
+              > "assets/${asset_name}"
+          done <<< "${assets}"
+
+      - name: Patch manifests with current release body
+        env:
+          RELEASE_SUMMARY: ${{ steps.find.outputs.body }}
+          RELEASE_URL: ${{ steps.find.outputs.url }}
+        run: |
+          set -euo pipefail
+          mkdir -p patched
+          for manifest in assets/*.manifest.json; do
+            jq --arg summary "${RELEASE_SUMMARY}" --arg url "${RELEASE_URL}" \
+              '.builds[].ota |= (.summary = $summary | .release_url = $url)' \
+              "${manifest}" > "patched/$(basename "${manifest}")"
+          done
+
+      - name: Re-upload patched manifests to draft release
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+          GH_REPO: ${{ github.repository }}
+          RELEASE_ID: ${{ steps.find.outputs.release_id }}
+        run: |
+          set -euo pipefail
+          # Upload by release id rather than `gh release upload <tag>
+          # --clobber` for the same reason as the download step: draft-by-tag
+          # resolution is unreliable. Clobber semantics are replicated by
+          # deleting any same-named asset before uploading.
+          if ! existing=$(gh api "repos/${GH_REPO}/releases/${RELEASE_ID}/assets" \
+            --paginate \
+            --jq '.[] | "\(.id)\t\(.name)"'); then
+            echo "::error::Failed to list draft release assets"
+            exit 1
+          fi
+          for manifest in patched/*.manifest.json; do
+            name=$(basename "${manifest}")
+            asset_id=$(awk -F'\t' -v name="${name}" '$2 == name {print $1; exit}' <<< "${existing}")
+            if [[ -n "${asset_id}" ]]; then
+              echo "Deleting existing asset ${name} (${asset_id})"
+              gh api "repos/${GH_REPO}/releases/assets/${asset_id}" \
+                --method DELETE --silent
+            fi
+            echo "Uploading ${name}"
+            gh api --method POST \
+              -H "Content-Type: application/json" \
+              "https://uploads.github.com/repos/${GH_REPO}/releases/${RELEASE_ID}/assets?name=${name}" \
+              --input "${manifest}" --silent
+          done
+
+      - name: Publish release
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+          GH_REPO: ${{ github.repository }}
+          RELEASE_ID: ${{ steps.find.outputs.release_id }}
+          TAG: ${{ steps.find.outputs.tag }}
+        run: |
+          set -euo pipefail
+          # Publish by id, not `gh release edit <tag> --draft=false`: besides
+          # the unreliable draft-by-tag resolution, gh sends a PATCH with only
+          # draft=false — and updating a draft without re-sending tag_name
+          # resets its tag to an untagged-* placeholder, which would then be
+          # published as the release tag.
+          gh api "repos/${GH_REPO}/releases/${RELEASE_ID}" \
+            --method PATCH \
+            --field "tag_name=${TAG}" \
+            --field "name=${TAG}" \
+            --field "draft=false" \
+            --silent
+          echo "Published ${TAG}"

--- a/.github/workflows/publish-firmware-to-r2.yml
+++ b/.github/workflows/publish-firmware-to-r2.yml
@@ -1,0 +1,238 @@
+name: Publish Firmware to Cloudflare R2
+# The `release: published` half of the pipeline: downloads the release's
+# firmware assets, reconstructs the artifact layout the R2 workflows expect
+# and uploads/promotes the firmware on https://firmware.esphome.io/.
+# This workflow is only to be used within the ESPHome organisation on
+# GitHub: the nested R2 workflows need the Cloudflare secrets, so it must be
+# called with `secrets: inherit`.
+
+on:
+  workflow_call:
+    inputs:
+      directory:
+        description: >-
+          Directory on https://firmware.esphome.io/ to publish to. Defaults
+          to the FIRMWARE_DIRECTORY repository variable if set, then to the
+          repository name singularized (e.g. rf-proxies -> rf-proxy).
+        required: false
+        type: string
+        default: ""
+      tag:
+        description: >-
+          Release tag to publish. Defaults to the release that triggered the
+          workflow; set it when re-publishing via workflow_dispatch.
+        required: false
+        type: string
+        default: ""
+
+jobs:
+  discover-devices:
+    name: Discover devices in release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      matrix: ${{ steps.find.outputs.matrix }}
+      directory: ${{ steps.directory.outputs.directory }}
+      version: ${{ steps.release.outputs.tag }}
+      release-id: ${{ steps.release.outputs.release_id }}
+      prerelease: ${{ steps.release.outputs.prerelease }}
+    steps:
+      - name: Determine firmware directory
+        id: directory
+        env:
+          INPUT_DIRECTORY: ${{ inputs.directory }}
+          # Set a `FIRMWARE_DIRECTORY` repository variable (or pass the
+          # `directory` input) to override the default, which is the
+          # repository name singularized (e.g. rf-proxies -> rf-proxy,
+          # media-players -> media-player). This is the directory used on
+          # https://firmware.esphome.io/ and must match the `update.source`
+          # URLs in the factory YAML files.
+          OVERRIDE: ${{ vars.FIRMWARE_DIRECTORY }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          repo_name="${GH_REPO#*/}"
+          directory="${INPUT_DIRECTORY:-${OVERRIDE}}"
+          if [[ -z "${directory}" ]]; then
+            if [[ "${repo_name}" == *ies ]]; then
+              directory="${repo_name%ies}y"
+            else
+              directory="${repo_name%s}"
+            fi
+          fi
+          echo "directory=${directory}" >> "$GITHUB_OUTPUT"
+          echo "Firmware directory: ${directory}"
+
+      - name: Resolve release
+        id: release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          INPUT_TAG: ${{ inputs.tag }}
+          EVENT_RELEASE_ID: ${{ github.event.release.id }}
+          EVENT_RELEASE_TAG: ${{ github.event.release.tag_name }}
+          EVENT_RELEASE_PRERELEASE: ${{ github.event.release.prerelease }}
+        run: |
+          set -euo pipefail
+          if [[ -n "${INPUT_TAG}" ]]; then
+            # Resolve via the releases list rather than the singular
+            # releases/tags/{tag} endpoint, which has proven unreliable;
+            # everything downstream operates by id.
+            if ! releases=$(gh api "repos/${GH_REPO}/releases?per_page=100"); then
+              echo "::error::Failed to list releases"
+              exit 1
+            fi
+            release=$(jq --arg tag "${INPUT_TAG}" \
+              '[.[] | select(.tag_name == $tag and .draft == false)] | first' <<< "${releases}")
+            if [[ -z "${release}" || "${release}" == "null" ]]; then
+              echo "::error::Published release ${INPUT_TAG} not found"
+              exit 1
+            fi
+            tag="${INPUT_TAG}"
+            release_id=$(jq -r '.id' <<< "${release}")
+            prerelease=$(jq -r '.prerelease' <<< "${release}")
+          elif [[ -n "${EVENT_RELEASE_ID}" ]]; then
+            tag="${EVENT_RELEASE_TAG}"
+            release_id="${EVENT_RELEASE_ID}"
+            prerelease="${EVENT_RELEASE_PRERELEASE}"
+          else
+            echo "::error::No release to publish; pass the tag input when not triggered by a release event"
+            exit 1
+          fi
+          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+          echo "release_id=${release_id}" >> "$GITHUB_OUTPUT"
+          echo "prerelease=${prerelease}" >> "$GITHUB_OUTPUT"
+          echo "Publishing ${tag} (id ${release_id}, prerelease: ${prerelease})"
+
+      - name: List devices from release manifests
+        id: find
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          RELEASE_ID: ${{ steps.release.outputs.release_id }}
+        run: |
+          set -euo pipefail
+          if ! names=$(gh api "repos/${GH_REPO}/releases/${RELEASE_ID}/assets" --paginate \
+            --jq '.[] | select(.name | endswith(".manifest.json")) | .name'); then
+            echo "::error::Failed to list release assets"
+            exit 1
+          fi
+          devices=$(sed 's/\.manifest\.json$//' <<< "${names}" \
+            | jq -R -s 'split("\n") | map(select(length > 0))')
+          if [[ "$(jq 'length' <<< "${devices}")" -eq 0 ]]; then
+            echo "::error::No <device>.manifest.json assets found on release"
+            exit 1
+          fi
+          echo "matrix=$(jq -c -n --argjson devices "${devices}" '{device: $devices}')" >> "$GITHUB_OUTPUT"
+          echo "Discovered devices: ${devices}"
+
+  prepare-artifact:
+    name: Prepare ${{ matrix.device }} artifact
+    needs: discover-devices
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.discover-devices.outputs.matrix) }}
+    steps:
+      - name: Download device assets and reconstruct layout
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          DEVICE: ${{ matrix.device }}
+          VERSION: ${{ needs.discover-devices.outputs.version }}
+          RELEASE_ID: ${{ needs.discover-devices.outputs.release-id }}
+        run: |
+          set -euo pipefail
+          # Recreate the <device>/<version>/{manifest.json,*.bin} layout that
+          # upload-to-r2 / promote-r2 expect from a build.yml run: the device
+          # name is embedded as the artifact's top-level directory so their
+          # merge-multiple downloads always yield files/<device>/<version>/.
+          target="output/${DEVICE}/${VERSION}"
+          mkdir -p "${target}"
+
+          # Download by asset id instead of `gh release download <tag>`: the
+          # singular releases/tags/{tag} endpoint gh uses to resolve the tag
+          # has proven unreliable, while asset listing/download by id works.
+          if ! assets=$(gh api "repos/${GH_REPO}/releases/${RELEASE_ID}/assets" --paginate \
+            --jq '.[] | "\(.id)\t\(.name)"'); then
+            echo "::error::Failed to list release assets"
+            exit 1
+          fi
+
+          download() {
+            local name="$1"
+            local asset_id
+            asset_id=$(awk -F'\t' -v name="${name}" '$2 == name {print $1; exit}' <<< "${assets}")
+            if [[ -z "${asset_id}" ]]; then
+              echo "::error::Asset ${name} not found on release"
+              return 1
+            fi
+            echo "Downloading ${name}"
+            gh api -H "Accept: application/octet-stream" \
+              "repos/${GH_REPO}/releases/assets/${asset_id}" > "${target}/${name}"
+          }
+
+          download "${DEVICE}.manifest.json"
+          mv "${target}/${DEVICE}.manifest.json" "${target}/manifest.json"
+
+          # Download only the binaries this device's manifest references
+          # (ota + parts) — avoids each matrix runner fetching every other
+          # device's bins.
+          if ! bins=$(jq -r '[
+            (.builds[]?.ota.path // empty),
+            (.builds[]?.parts[]?.path // empty)
+          ] | unique | .[]' "${target}/manifest.json"); then
+            echo "::error::Failed to parse ${DEVICE} manifest"
+            exit 1
+          fi
+          while IFS= read -r bin; do
+            [[ -z "${bin}" ]] && continue
+            download "${bin}"
+          done <<< "${bins}"
+
+      - name: Upload firmware artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ matrix.device }}
+          path: output
+          if-no-files-found: error
+
+  upload-to-r2:
+    name: Upload to R2
+    needs:
+      - discover-devices
+      - prepare-artifact
+    uses: ./.github/workflows/upload-to-r2.yml
+    with:
+      directory: ${{ needs.discover-devices.outputs.directory }}
+    secrets: inherit
+
+  promote-beta:
+    name: Promote to Beta
+    needs:
+      - discover-devices
+      - upload-to-r2
+    uses: ./.github/workflows/promote-r2.yml
+    with:
+      version: ${{ needs.discover-devices.outputs.version }}
+      directory: ${{ needs.discover-devices.outputs.directory }}
+      channel: beta
+      manifest-filename: manifest-beta.json
+    secrets: inherit
+
+  promote-prod:
+    name: Promote to Production
+    if: needs.discover-devices.outputs.prerelease == 'false'
+    needs:
+      - discover-devices
+      - upload-to-r2
+    uses: ./.github/workflows/promote-r2.yml
+    with:
+      version: ${{ needs.discover-devices.outputs.version }}
+      directory: ${{ needs.discover-devices.outputs.directory }}
+      channel: production
+      manifest-filename: manifest.json
+    secrets: inherit

--- a/README.md
+++ b/README.md
@@ -11,6 +11,20 @@ This repository contains workflows to be used by other repositories.
 - `promote-r2.yml` - Promote R2 releases
 - `lock.yml` - Lock workflow
 
+### Draft-Release Pipeline
+
+Reusable workflows for the ready-made-project repositories' release pipeline
+(draft a CalVer release, build into the draft, publish it, then push the
+firmware to https://firmware.esphome.io/):
+- `draft-calver-release.yml` - Create/update a CalVer (YY.M.N) draft release
+  with release-drafter
+- `build-to-draft-release.yml` - Build firmware and replace the draft
+  release's assets
+- `publish-draft-release.yml` - Patch manifest assets with the final release
+  notes and publish the draft
+- `publish-firmware-to-r2.yml` - Push a published release's firmware to R2
+  and promote it
+
 
 ## Usage
 
@@ -25,3 +39,11 @@ scenarios, verifies the downloaded artifact layout, and exercises
 `upload-to-gh-release.yml` against a draft release that is deleted afterwards.
 The R2 workflows are not run end-to-end (they need Cloudflare secrets), but
 they consume artifacts the same way the verified workflows do.
+
+`ci-draft-release.yml` smoke-tests `build-to-draft-release.yml` (factory
+config auto-discovery plus the nested `build.yml` call). The draft-release
+jobs themselves are not exercised in CI: they only run for `workflow_run`
+events in consumer repositories and need a live draft release. The same goes
+for `draft-calver-release.yml`, `publish-draft-release.yml` and
+`publish-firmware-to-r2.yml`, which need a consumer repository's releases,
+GitHub App credentials and Cloudflare secrets.

--- a/tests/ci-draft.factory.yaml
+++ b/tests/ci-draft.factory.yaml
@@ -1,0 +1,23 @@
+esphome:
+  name: ci-draft
+  friendly_name: CI Draft
+  project:
+    name: esphome.workflows-ci
+    version: dev
+
+esp8266:
+  board: esp01_1m
+
+logger:
+
+api:
+
+ota:
+  - platform: esphome
+
+improv_serial:
+
+wifi:
+  ap: {}
+
+captive_portal:


### PR DESCRIPTION
## Summary

Extracts the generic draft-release pipeline currently copy-pasted into every ready-made-project repository (rf-proxies, bluetooth-proxies, infrared-proxies, media-players, firmware, serial-proxies, wake-word-voice-assistants, all generated from esphome/ready-made-project-template) into four `workflow_call` reusable workflows, so the GitHub draft-release protocol knowledge lives here once and the per-repo files become thin callers.

- `draft-calver-release.yml` — computes the next CalVer version (YY.M.N, reusing the highest-sequence draft if still a draft) and runs release-drafter with it. The release-drafter config is still read from the caller repo, so each consumer keeps its own categories.
- `build-to-draft-release.yml` — the whole `workflow_run` pipeline: discover `*.factory.yaml` configs (or take an explicit `files` input), read the current draft release, build via the nested `./build.yml`, clean the draft's assets, upload via the nested `./upload-to-gh-release.yml`, and strip the ASSETS_PENDING warning. The event gating lives inside, so callers shrink to trigger + concurrency + one `uses:` job passing `esphome-version`.
- `publish-draft-release.yml` — resolves the draft (optional `tag` input, defaults to the most recent non-orphaned draft), patches the `*.manifest.json` assets with the final release body/URL, re-uploads them, and publishes — all authenticated with the ESPHome GitHub App token so `release: published` fires downstream.
- `publish-firmware-to-r2.yml` — the `release: published` half: discovers devices from the release's manifest assets, reconstructs the artifact layout the R2 workflows expect, and runs the nested upload/promote R2 workflows (beta always, production when not a prerelease).

The workflows encode the draft-release API behaviour verified live over the last two days: every PATCH to a draft re-sends `tag_name` and `name` (omitting them resets the draft to an `untagged-*` placeholder), drafts whose tag was reset to `untagged-*` are ignored, and all by-tag operations are replaced with list-then-operate-by-id (the singular `releases/tags/{tag}` endpoint that `gh release` subcommands rely on has proven unreliable for drafts).

Two details worth reviewing:

- `determine-version` in `build-to-draft-release.yml` intentionally has no `permissions:` block: a called-workflow job requesting `contents: write` fails at startup on pull requests from forks, where the token cannot be elevated. The write-requesting jobs are all gated to `workflow_run` events instead, and the caller grants `contents: write` at workflow level.
- The new `ci-draft-release.yml` smoke-tests `build-to-draft-release.yml` (factory-config auto-discovery + the nested build) as a separate workflow run, because `ci.yml`'s `test-gh-release` job downloads every artifact of its own run and the smoke build's artifact carries a different version directory. The draft-release jobs themselves cannot run in CI (they need a `workflow_run` event and a live draft release).

Builds on #167: `publish-firmware-to-r2.yml` reconstructs artifacts under the name-embedded layout introduced there, so consumers must pin a release containing both.

The ready-made-project-template will be converted to call these first (caller snippets already handed over to that effort), then the fleet follows.