### PR TITLE
Construct release URLs from the tag instead of the draft html_url

### DIFF
--- a/.github/workflows/build-to-draft-release.yml
+++ b/.github/workflows/build-to-draft-release.yml
@@ -107,7 +107,10 @@ jobs:
               exit 1
             fi
             tag=$(jq -r '.tag_name' <<< "${release_json}")
-            url=$(jq -r '.html_url' <<< "${release_json}")
+            # Do NOT use the draft's html_url: for a draft it always points
+            # at an untagged-* placeholder that 404s once the release is
+            # published. The final URL is deterministic from the tag.
+            url="https://github.com/${GH_REPO}/releases/tag/${tag}"
             # Strip the ASSETS_PENDING caution block from the draft body before
             # baking it into the firmware as release-summary; the warning is
             # only meant for the maintainer viewing the draft on GitHub.

--- a/.github/workflows/publish-draft-release.yml
+++ b/.github/workflows/publish-draft-release.yml
@@ -81,7 +81,10 @@ jobs:
           fi
           echo "tag=${tag}" >> "$GITHUB_OUTPUT"
           echo "release_id=$(jq -r '.id' <<< "${release}")" >> "$GITHUB_OUTPUT"
-          echo "url=$(jq -r '.html_url' <<< "${release}")" >> "$GITHUB_OUTPUT"
+          # Do NOT use the draft's html_url: for a draft it always points at
+          # an untagged-* placeholder that 404s once the release is
+          # published. The final URL is deterministic from the tag.
+          echo "url=https://github.com/${GH_REPO}/releases/tag/${tag}" >> "$GITHUB_OUTPUT"
           {
             echo "body<<RELEASE_BODY_EOF"
             jq -r '.body' <<< "${release}"


### PR DESCRIPTION
## Summary

Follow-up to #168, fixing a fleet-wide defect surfaced by a review on esphome/serial-proxies: shipped manifests carry `ota.release_url` values like `https://github.com/esphome/serial-proxies/releases/tag/untagged-48a68f5b50a03b2b1927`, which 404.

The root cause is not the tag-reset failure the workflows already guard against: a draft release's `html_url` **always** points at an `untagged-*` placeholder until the release is published, even when its `tag_name` is healthy (verified live: the current esphome/infrared-proxies draft has `tag_name: 26.7.2` but an `untagged-*` `html_url`). So every firmware built against a draft, and every manifest patched at publish time, baked in a URL that 404s the moment the release goes live.

Since the final URL is deterministic from the tag, construct `https://github.com/<repo>/releases/tag/<tag>` instead of reading `.html_url`, in both places that emit it:

- `build-to-draft-release.yml` `determine-version` (the URL baked into the firmware)
- `publish-draft-release.yml` resolve step (the URL patched into the `*.manifest.json` assets before publishing)

No per-repo fixes are needed: converting the fleet to these workflows fixes the defect going forward. Manifests on already-published releases keep the broken URL until each repository's next release.