### PR TITLE
Support grouped builds in build-to-draft-release

### DIFF
--- a/.github/workflows/build-to-draft-release.yml
+++ b/.github/workflows/build-to-draft-release.yml
@@ -4,6 +4,21 @@ name: Build to Draft Release
 # it on pull_request / workflow_dispatch (build only) and on workflow_run of
 # their Release Drafter workflow (build and upload to the draft); the event
 # gating lives in here, so callers stay a single `uses:` job.
+#
+# The draft's existing assets are not cleaned here: draft-calver-release.yml
+# empties them when it re-adds the ASSETS_PENDING warning, before this
+# workflow is triggered. This workflow only ever adds assets.
+#
+# Repositories that publish several combined manifests from one release (e.g.
+# esphome/firmware's esp-web-tools and esphome-web) express that with the
+# `groups` input and still call this workflow once. Grouping lives inside a
+# single call because removing the pending warning is a claim that the whole
+# release is built, and only one job can make it: split across a call per
+# group, whichever call finished first would strip the warning while the
+# others were still compiling, inviting a maintainer to publish a release
+# missing a group. One call also keeps one upload job — upload-to-gh-release
+# takes every artifact in the run, so two calls in one workflow would upload
+# each other's artifacts and race on identical asset names.
 
 on:
   workflow_call:
@@ -15,14 +30,39 @@ on:
       files:
         description: >-
           Newline separated list of files to build. Leave empty to build
-          every *.factory.yaml in the calling repository.
+          every *.factory.yaml in the calling repository. Mutually exclusive
+          with `groups`.
+        required: false
+        type: string
+        default: ""
+      combined-name:
+        description: >-
+          Combine every built file into a single manifest published under
+          this name. Leave empty to publish one manifest per file. Mutually
+          exclusive with `groups`; use `groups` to publish more than one
+          combined manifest from the same release.
+        required: false
+        type: string
+        default: ""
+      groups:
+        description: >-
+          JSON array of {"name": ..., "files": ...} objects, to publish
+          several combined manifests from one release. Each group builds its
+          own `files` (newline separated) into a single manifest named
+          `name`, and every group's assets are uploaded to the same draft.
+          Names must be unique; one group may use an empty name to publish
+          its files as one manifest each instead of combining them.
+          Per-group `files` is required and is not auto-discovered: discovery
+          globs *.factory.yaml across the whole repository, so one group would
+          sweep up another group's configs. Mutually exclusive with `files`
+          and `combined-name`.
         required: false
         type: string
         default: ""
 
 jobs:
   discover-files:
-    name: Discover Factory Configs
+    name: Resolve Build Groups
     # Skip the entire pipeline if the Release Drafter run that triggered us failed.
     if: >-
       github.event_name != 'workflow_run' ||
@@ -31,36 +71,79 @@ jobs:
     permissions:
       contents: read
     outputs:
-      files: ${{ steps.find.outputs.files }}
+      groups: ${{ steps.find.outputs.groups }}
     steps:
       - name: Checkout code
-        if: inputs.files == ''
+        # Only the auto-discovery path reads the repository; every other form
+        # states its files up front.
+        if: inputs.files == '' && inputs.groups == ''
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - name: Find factory configs
+      - name: Resolve build groups
         id: find
         env:
           INPUT_FILES: ${{ inputs.files }}
+          INPUT_COMBINED_NAME: ${{ inputs.combined-name }}
+          INPUT_GROUPS: ${{ inputs.groups }}
         run: |
           set -euo pipefail
-          files="${INPUT_FILES}"
-          if [[ -z "${files}" ]]; then
-            # By convention every device ships a <device>/<device>.factory.yaml;
-            # anything matching *.factory.yaml outside hidden directories is
-            # built. Prune dot-directories (.git, .github) rather than just
-            # filtering them from the results, so find never descends into them.
-            files=$(find . -path '*/.*' -prune -o -name '*.factory.yaml' -print | sed 's|^\./||' | sort)
+          # Both input forms normalise to one JSON array of {name, files}, so
+          # the build matrix below has a single shape to consume. The
+          # single-group form carries name "" — build.yml reads that as "do
+          # not combine" and publishes one manifest per file, which is the
+          # behaviour callers that pass neither input have always had.
+          if [[ -n "${INPUT_GROUPS}" ]]; then
+            if [[ -n "${INPUT_FILES}" || -n "${INPUT_COMBINED_NAME}" ]]; then
+              echo "::error::groups cannot be combined with files or combined-name"
+              exit 1
+            fi
+            if ! groups=$(jq -ce . <<< "${INPUT_GROUPS}"); then
+              echo "::error::groups is not valid JSON"
+              exit 1
+            fi
+            # An empty name is allowed and means "publish these per file"
+            # rather than combining them, for repositories that ship a
+            # combined group alongside standalone devices. The uniqueness
+            # check keeps that to at most one group.
+            # jq's or short-circuits, so .name is never indexed on a non-object.
+            if ! problem=$(jq -r '
+              if type != "array" then "groups must be a JSON array"
+              elif length == 0 then "groups must not be empty"
+              elif any(.[];
+                (type != "object")
+                or ((.name | type) != "string")
+                or ((.files | type) != "string") or (.files == "")
+              ) then "every group needs a string name and a non-empty files"
+              elif ([.[].name] | length) != ([.[].name] | unique | length)
+              then "group names must be unique"
+              else empty
+              end' <<< "${groups}"); then
+              echo "::error::Failed to validate groups"
+              exit 1
+            fi
+            if [[ -n "${problem}" ]]; then
+              echo "::error::${problem}"
+              exit 1
+            fi
+          else
+            files="${INPUT_FILES}"
+            if [[ -z "${files}" ]]; then
+              # By convention every device ships a <device>/<device>.factory.yaml;
+              # anything matching *.factory.yaml outside hidden directories is
+              # built. Prune dot-directories (.git, .github) rather than just
+              # filtering them from the results, so find never descends into them.
+              files=$(find . -path '*/.*' -prune -o -name '*.factory.yaml' -print | sed 's|^\./||' | sort)
+            fi
+            if [[ -z "${files}" ]]; then
+              echo "::error::No *.factory.yaml files found"
+              exit 1
+            fi
+            groups=$(jq -cn --arg name "${INPUT_COMBINED_NAME}" --arg files "${files}" \
+              '[{name: $name, files: $files}]')
           fi
-          if [[ -z "${files}" ]]; then
-            echo "::error::No *.factory.yaml files found"
-            exit 1
-          fi
-          echo "Files to build:"
-          echo "${files}"
-          {
-            echo "files<<FACTORY_FILES_EOF"
-            echo "${files}"
-            echo "FACTORY_FILES_EOF"
-          } >> "$GITHUB_OUTPUT"
+          echo "Groups to build:"
+          jq -r '.[] | "  \(if .name == "" then "(one manifest per file)" else .name end):",
+                       (.files | split("\n") | .[] | "    \(.)")' <<< "${groups}"
+          echo "groups=${groups}" >> "$GITHUB_OUTPUT"
 
   determine-version:
     name: Determine Version
@@ -74,7 +157,7 @@ jobs:
     # visible to tokens with push access), which the caller must grant on
     # every event anyway: GitHub validates each nested job's requested
     # permissions against the caller's grant when the workflow is called,
-    # even for jobs that end up skipped (see clean-draft-assets below).
+    # even for jobs that end up skipped (see upload-to-draft-release below).
     outputs:
       version: ${{ steps.info.outputs.version }}
       summary: ${{ steps.info.outputs.summary }}
@@ -128,65 +211,40 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
   build-firmware:
-    name: Build Firmware
+    # One leg per group; the legacy single-group form resolves to exactly one
+    # leg named "Build Firmware", as before.
+    name: Build ${{ matrix.group.name || 'Firmware' }}
     needs:
       - discover-files
       - determine-version
+    strategy:
+      # Let every group report its own failure instead of cancelling its
+      # siblings. upload-to-draft-release needs this whole job, so a failed
+      # leg still means nothing is uploaded and the draft keeps its pending
+      # warning.
+      fail-fast: false
+      matrix:
+        group: ${{ fromJson(needs.discover-files.outputs.groups) }}
     uses: ./.github/workflows/build.yml
     with:
-      files: ${{ needs.discover-files.outputs.files }}
+      files: ${{ matrix.group.files }}
+      combined-name: ${{ matrix.group.name }}
       esphome-version: ${{ inputs.esphome-version }}
       release-summary: ${{ needs.determine-version.outputs.summary }}
       release-url: ${{ needs.determine-version.outputs.url }}
       release-version: ${{ needs.determine-version.outputs.version }}
 
-  clean-draft-assets:
-    name: Clean Draft Release Assets
-    # Delete any pre-existing assets so renamed files (e.g. when the version
-    # bumps from .1 to .2) don't linger alongside the new ones. Gated on
-    # build success so a failed build doesn't leave the draft release empty.
-    if: github.event_name == 'workflow_run'
-    needs:
-      - build-firmware
-      - determine-version
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - name: Delete existing assets from draft release
-        env:
-          GH_TOKEN: ${{ github.token }}
-          GH_REPO: ${{ github.repository }}
-          TAG: ${{ needs.determine-version.outputs.version }}
-        run: |
-          set -euo pipefail
-          if ! releases=$(gh api "repos/${GH_REPO}/releases?per_page=100"); then
-            echo "::error::Failed to list releases"
-            exit 1
-          fi
-          release=$(jq --arg tag "${TAG}" \
-            '[.[] | select(.tag_name == $tag and .draft == true)] | first' <<< "${releases}")
-          if [[ -z "${release}" || "${release}" == "null" ]]; then
-            echo "Draft release ${TAG} not found; nothing to clean"
-            exit 0
-          fi
-          release_id=$(jq -r '.id' <<< "${release}")
-          if ! asset_ids=$(gh api "repos/${GH_REPO}/releases/${release_id}/assets" --paginate --jq '.[].id'); then
-            echo "::error::Failed to list draft release assets"
-            exit 1
-          fi
-          for id in ${asset_ids}; do
-            echo "Deleting asset ${id}"
-            gh api "repos/${GH_REPO}/releases/assets/${id}" --method DELETE --silent
-          done
-
   upload-to-draft-release:
     name: Upload to Draft Release
+    # Uploads every group in one job: upload-to-gh-release.yml downloads all
+    # of the run's artifacts, and each group's build published its manifest as
+    # an artifact of this same run. It replaces any same-named asset, so this
+    # stays correct when a build is re-run without the drafter having emptied
+    # the draft again.
     if: github.event_name == 'workflow_run'
     needs:
       - build-firmware
       - determine-version
-      - clean-draft-assets
     permissions:
       contents: write
     uses: ./.github/workflows/upload-to-gh-release.yml

--- a/.github/workflows/build-to-draft-release.yml
+++ b/.github/workflows/build-to-draft-release.yml
@@ -112,7 +112,7 @@ jobs:
                 (type != "object")
                 or ((.name | type) != "string")
                 or ((.files | type) != "string") or (.files == "")
-              ) then "every group needs a string name and a non-empty files"
+              ) then "every group needs a string name and a non-empty files string"
               elif ([.[].name] | length) != ([.[].name] | unique | length)
               then "group names must be unique"
               else empty

--- a/.github/workflows/build-to-draft-release.yml
+++ b/.github/workflows/build-to-draft-release.yml
@@ -46,9 +46,9 @@ on:
         default: ""
       groups:
         description: >-
-          JSON array of {"name": ..., "files": ...} objects, to publish
+          JSON array of {"name": ..., "files": [...]} objects, to publish
           several combined manifests from one release. Each group builds its
-          own `files` (newline separated) into a single manifest named
+          own `files` (a JSON array of paths) into a single manifest named
           `name`, and every group's assets are uploaded to the same draft.
           Names must be unique; one group may use an empty name to publish
           its files as one manifest each instead of combining them.
@@ -104,15 +104,17 @@ jobs:
             # rather than combining them, for repositories that ship a
             # combined group alongside standalone devices. The uniqueness
             # check keeps that to at most one group.
-            # jq's or short-circuits, so .name is never indexed on a non-object.
+            # jq's or short-circuits, so .files/.name are never indexed on a
+            # non-object.
             if ! problem=$(jq -r '
               if type != "array" then "groups must be a JSON array"
               elif length == 0 then "groups must not be empty"
               elif any(.[];
                 (type != "object")
                 or ((.name | type) != "string")
-                or ((.files | type) != "string") or (.files == "")
-              ) then "every group needs a string name and a non-empty files string"
+                or ((.files | type) != "array") or ((.files | length) == 0)
+                or (.files | any(.[]; (type != "string") or (. == "")))
+              ) then "every group needs a string name and a non-empty files array of non-empty strings"
               elif ([.[].name] | length) != ([.[].name] | unique | length)
               then "group names must be unique"
               else empty
@@ -124,6 +126,11 @@ jobs:
               echo "::error::${problem}"
               exit 1
             fi
+            # Flatten each group's files array to the newline-separated string
+            # build.yml consumes, so the matrix leg passes it through unchanged.
+            # jq -c keeps the embedded newlines as \n, so the output stays on a
+            # single line for GITHUB_OUTPUT.
+            groups=$(jq -c '[.[] | {name, files: (.files | join("\n"))}]' <<< "${groups}")
           else
             files="${INPUT_FILES}"
             if [[ -z "${files}" ]]; then

--- a/.github/workflows/ci-draft-release.yml
+++ b/.github/workflows/ci-draft-release.yml
@@ -36,11 +36,35 @@ jobs:
       # finds tests/ci-draft.factory.yaml (the only factory config here).
       esphome-version: latest
 
+  # A repository publishing several combined manifests from one release (the
+  # esphome/firmware shape) makes a single call with `groups`. Proves the
+  # build matrix fans a reusable-workflow call out per group, that per-group
+  # newline separated files survive the matrix, and that both groups'
+  # artifacts land in the same run — which is what lets the one
+  # upload-to-draft-release job publish all of them.
+  build-to-draft-groups:
+    name: Build to draft release (grouped smoke)
+    uses: ./.github/workflows/build-to-draft-release.yml
+    with:
+      esphome-version: latest
+      groups: |
+        [
+          {
+            "name": "ci-draft-group-a",
+            "files": "tests/ci-combined-a.yaml\ntests/ci-combined-b.yaml"
+          },
+          {
+            "name": "ci-draft-group-b",
+            "files": "tests/ci-combined-single.yaml"
+          }
+        ]
+
   verify-artifacts:
     name: Verify artifact layout
     runs-on: ubuntu-latest
     needs:
       - build-to-draft
+      - build-to-draft-groups
     steps:
       - name: Download all artifacts (as the upload workflows do)
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -53,27 +77,53 @@ jobs:
 
       - name: Verify layout
         run: |
+          shopt -s nullglob
           fail=0
 
           # Without a draft release to take a version from, build.yml
-          # generates a dev-<timestamp> version.
-          if ! compgen -G "files/ci-draft/dev-*/manifest.json" > /dev/null; then
-            echo "::error::Missing files/ci-draft/dev-*/manifest.json"
-            fail=1
-          fi
-
-          shopt -s nullglob
-          bins=(files/ci-draft/dev-*/*.bin)
-          if [ "${#bins[@]}" -eq 0 ]; then
-            echo "::error::No firmware binaries in files/ci-draft/dev-*/"
-            fail=1
-          fi
-
-          for entry in files/*; do
-            if [ "$(basename "$entry")" != "ci-draft" ]; then
-              echo "::error::Unexpected top-level entry: $entry"
+          # generates a dev-<timestamp> version. Each call generates its own,
+          # so match with a glob rather than assuming one shared value.
+          for name in ci-draft ci-draft-group-a ci-draft-group-b; do
+            if ! compgen -G "files/$name/dev-*/manifest.json" > /dev/null; then
+              echo "::error::Missing files/$name/dev-*/manifest.json"
               fail=1
             fi
+            bins=(files/"$name"/dev-*/*.bin)
+            if [ "${#bins[@]}" -eq 0 ]; then
+              echo "::error::No firmware binaries in files/$name/dev-*/"
+              fail=1
+            fi
+          done
+
+          # Every group's manifest is present and combines exactly its own
+          # files: a group must not absorb another group's builds, and the
+          # ungrouped call must stay one manifest per file.
+          for spec in ci-draft:1 ci-draft-group-a:2 ci-draft-group-b:1; do
+            name="${spec%:*}"
+            expected="${spec#*:}"
+            manifests=(files/"$name"/dev-*/manifest.json)
+            if [ "${#manifests[@]}" -ne 1 ]; then
+              echo "::error::Expected exactly one manifest for $name, found ${#manifests[@]}"
+              fail=1
+              continue
+            fi
+            if ! builds=$(jq '.builds | length' "${manifests[0]}"); then
+              echo "::error::Failed to read the $name manifest"
+              fail=1
+            elif [ "$builds" -ne "$expected" ]; then
+              echo "::error::$name manifest has $builds builds, expected $expected"
+              fail=1
+            fi
+          done
+
+          for entry in files/*; do
+            case "$(basename "$entry")" in
+              ci-draft|ci-draft-group-a|ci-draft-group-b) ;;
+              *)
+                echo "::error::Unexpected top-level entry: $entry"
+                fail=1
+                ;;
+            esac
           done
 
           exit $fail

--- a/.github/workflows/ci-draft-release.yml
+++ b/.github/workflows/ci-draft-release.yml
@@ -38,8 +38,8 @@ jobs:
 
   # A repository publishing several combined manifests from one release (the
   # esphome/firmware shape) makes a single call with `groups`. Proves the
-  # build matrix fans a reusable-workflow call out per group, that per-group
-  # newline separated files survive the matrix, and that both groups'
+  # build matrix fans a reusable-workflow call out per group, that a group's
+  # multi-file `files` array survives the matrix, and that both groups'
   # artifacts land in the same run — which is what lets the one
   # upload-to-draft-release job publish all of them.
   build-to-draft-groups:
@@ -51,11 +51,11 @@ jobs:
         [
           {
             "name": "ci-draft-group-a",
-            "files": "tests/ci-combined-a.yaml\ntests/ci-combined-b.yaml"
+            "files": ["tests/ci-combined-a.yaml", "tests/ci-combined-b.yaml"]
           },
           {
             "name": "ci-draft-group-b",
-            "files": "tests/ci-combined-single.yaml"
+            "files": ["tests/ci-combined-single.yaml"]
           }
         ]
 

--- a/.github/workflows/draft-calver-release.yml
+++ b/.github/workflows/draft-calver-release.yml
@@ -1,8 +1,14 @@
 name: Draft CalVer Release
 # Computes the next CalVer version (YY.M.N) and creates or updates a draft
-# release for it with release-drafter. The release-drafter action reads
-# .github/release-drafter.yml from the calling repository at runtime, so each
-# consumer keeps its own release-notes configuration.
+# release for it with release-drafter, then empties the draft's assets. The
+# release-drafter action reads .github/release-drafter.yml from the calling
+# repository at runtime, so each consumer keeps its own release-notes
+# configuration.
+#
+# Emptying the assets here makes this workflow the single writer that resets
+# a release cycle: the build workflows that run afterwards (on workflow_run
+# of the caller's Release Drafter workflow) can assume a clean draft and just
+# add their own assets, however many of them there are.
 
 on:
   workflow_call:
@@ -65,9 +71,50 @@ jobs:
           echo "Calculated calver version: ${version}"
 
       - uses: release-drafter/release-drafter@4d75298e00d9e34c483e5ff8c68d0ea1c1940c1e # v7.5.1
+        id: drafter
         with:
           version: ${{ steps.calver.outputs.version }}
           tag: ${{ steps.calver.outputs.version }}
           name: ${{ steps.calver.outputs.version }}
         env:
           GITHUB_TOKEN: ${{ github.token }}
+
+      # release-drafter has just rewritten the body from the caller's
+      # template, which re-adds its ASSETS_PENDING warning: the draft now
+      # declares that it has no build assets, so make that true.
+      #
+      # This is the only point where deleting every asset is unambiguous.
+      # Anything still attached belongs to an earlier build of this draft, and
+      # no build is in flight yet — the build workflows only start once this
+      # workflow has completed. A clean that runs alongside the builds cannot
+      # tell a stale asset from one another build just uploaded, which is what
+      # would otherwise force every repository into a single build+upload call
+      # per release.
+      #
+      # Uses the id release-drafter just reported rather than searching for
+      # "the first draft", so it can never empty the wrong release.
+      - name: Delete stale assets from the draft release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          RELEASE_ID: ${{ steps.drafter.outputs.id }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${RELEASE_ID}" ]]; then
+            echo "::error::release-drafter did not report a release id"
+            exit 1
+          fi
+          if ! asset_ids=$(gh api "repos/${GH_REPO}/releases/${RELEASE_ID}/assets" \
+              --paginate --jq '.[].id'); then
+            echo "::error::Failed to list assets for release ${RELEASE_ID}"
+            exit 1
+          fi
+          # A bare `while read <<< ""` would loop once on an empty id.
+          if [[ -z "${asset_ids}" ]]; then
+            echo "Draft release ${RELEASE_ID} has no assets to delete"
+            exit 0
+          fi
+          while read -r id; do
+            echo "Deleting asset ${id}"
+            gh api "repos/${GH_REPO}/releases/assets/${id}" --method DELETE --silent
+          done <<< "${asset_ids}"

--- a/.github/workflows/draft-calver-release.yml
+++ b/.github/workflows/draft-calver-release.yml
@@ -104,6 +104,18 @@ jobs:
             echo "::error::release-drafter did not report a release id"
             exit 1
           fi
+          # release-drafter maintains a draft, but refuse to touch the release
+          # unless it actually is one: deleting a published release's assets
+          # would be irreversible, so a misconfigured caller must fail loudly
+          # here rather than lose published firmware.
+          if ! release=$(gh api "repos/${GH_REPO}/releases/${RELEASE_ID}"); then
+            echo "::error::Failed to fetch release ${RELEASE_ID}"
+            exit 1
+          fi
+          if [[ "$(jq -r '.draft' <<< "${release}")" != "true" ]]; then
+            echo "::error::Release ${RELEASE_ID} is not a draft; refusing to delete its assets"
+            exit 1
+          fi
           if ! asset_ids=$(gh api "repos/${GH_REPO}/releases/${RELEASE_ID}/assets" \
               --paginate --jq '.[].id'); then
             echo "::error::Failed to list assets for release ${RELEASE_ID}"

--- a/README.md
+++ b/README.md
@@ -17,9 +17,12 @@ Reusable workflows for the ready-made-project repositories' release pipeline
 (draft a CalVer release, build into the draft, publish it, then push the
 firmware to https://firmware.esphome.io/):
 - `draft-calver-release.yml` - Create/update a CalVer (YY.M.N) draft release
-  with release-drafter
+  with release-drafter, and empty its assets so the build workflows that run
+  afterwards start from a clean draft
 - `build-to-draft-release.yml` - Build firmware and replace the draft
-  release's assets
+  release's assets. Repositories that publish several combined manifests from
+  one release pass `groups` and still call it once — see
+  [Grouped builds](#grouped-builds)
 - `publish-draft-release.yml` - Patch manifest assets with the final release
   notes and publish the draft
 - `publish-firmware-to-r2.yml` - Push a published release's firmware to R2
@@ -29,6 +32,87 @@ firmware to https://firmware.esphome.io/):
 ## Usage
 
 See https://github.com/esphome/esphome-project-template for usage of these workflows.
+
+### Grouped builds
+
+By default `build-to-draft-release.yml` publishes one manifest per built file.
+Pass `combined-name` to merge every file into a single manifest instead:
+
+```yaml
+jobs:
+  build:
+    uses: esphome/workflows/.github/workflows/build-to-draft-release.yml@<ref>
+    permissions:
+      contents: write
+    with:
+      esphome-version: 2026.5.3
+      files: esp32-generic.yaml
+      combined-name: esp32-generic
+```
+
+A repository that publishes **several** combined manifests from the same
+release passes `groups` — a JSON array of `{"name": ..., "files": ...}` — and
+still calls the workflow **once**:
+
+```yaml
+jobs:
+  build:
+    uses: esphome/workflows/.github/workflows/build-to-draft-release.yml@<ref>
+    permissions:
+      contents: write
+    with:
+      esphome-version: 2026.5.3
+      groups: |
+        [
+          {"name": "esp-web-tools", "files": "esp-web-tools/esp32.yaml\nesp-web-tools/esp8266.yaml"},
+          {"name": "esphome-web", "files": "esphome-web/esp32.factory.yaml"}
+        ]
+```
+
+Each group builds into its own combined manifest, and every group's assets are
+uploaded to the same draft release. One group may use an empty name, meaning
+"publish these files as one manifest each" — for repositories that ship a
+combined group alongside standalone devices:
+
+```yaml
+      groups: |
+        [
+          {"name": "esp32-generic", "files": "esp32-generic/esp32-generic.factory.yaml"},
+          {"name": "", "files": "gl-inet/gl-s10.factory.yaml\nwt32/wt32-eth01.factory.yaml"}
+        ]
+```
+
+Group these in one call rather than calling the workflow once per group.
+Removing the draft's "assets pending" warning is a claim that the whole
+release is built, and only one job can make it: split across a call per group,
+whichever call finished first would strip the warning while the others were
+still compiling, inviting a maintainer to publish a release missing a group.
+One call also keeps a single upload job — `upload-to-gh-release.yml` takes
+every artifact in the run, so two calls in one workflow would upload each
+other's artifacts and race on identical asset names.
+
+Per-group `files` is required. The `*.factory.yaml` auto-discovery (`files`
+left empty) globs the whole repository, so it only makes sense for the
+single-group form; inside `groups` it would sweep one group's configs into
+another. `groups` is therefore mutually exclusive with `files` and
+`combined-name`.
+
+### Draft asset lifecycle
+
+`build-to-draft-release.yml` never deletes the draft's assets; it only adds
+them. `draft-calver-release.yml` empties the draft when release-drafter
+re-applies the release notes (and with them the "assets pending" warning),
+which happens before the build workflows are triggered.
+
+That placement is deliberate. It is the only point where deleting every asset
+is unambiguous: nothing is building yet, so anything still attached is from an
+earlier build of the same draft. A clean running alongside the builds cannot
+tell a stale asset from one another build has just uploaded.
+
+Consequently a repository must use **both** halves of the pipeline. A
+repository whose Release Drafter workflow does not call
+`draft-calver-release.yml` never empties its draft, and assets for a device
+that is later renamed or removed will linger on it.
 
 ## CI
 
@@ -40,10 +124,12 @@ scenarios, verifies the downloaded artifact layout, and exercises
 The R2 workflows are not run end-to-end (they need Cloudflare secrets), but
 they consume artifacts the same way the verified workflows do.
 
-`ci-draft-release.yml` smoke-tests `build-to-draft-release.yml` (factory
-config auto-discovery plus the nested `build.yml` call). The draft-release
-jobs themselves are not exercised in CI: they only run for `workflow_run`
-events in consumer repositories and need a live draft release. The same goes
+`ci-draft-release.yml` smoke-tests `build-to-draft-release.yml`: factory
+config auto-discovery plus the nested `build.yml` call, and a `groups` call
+that checks each group produces its own combined manifest without absorbing
+another group's builds. The draft-release jobs themselves are not exercised
+in CI: they only run for `workflow_run` events in consumer repositories and
+need a live draft release. The same goes
 for `draft-calver-release.yml`, `publish-draft-release.yml` and
 `publish-firmware-to-r2.yml`, which need a consumer repository's releases,
 GitHub App credentials and Cloudflare secrets.

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ jobs:
 ```
 
 A repository that publishes **several** combined manifests from the same
-release passes `groups` — a JSON array of `{"name": ..., "files": ...}` — and
+release passes `groups` — a JSON array of `{"name": ..., "files": [...]}` — and
 still calls the workflow **once**:
 
 ```yaml
@@ -64,8 +64,8 @@ jobs:
       esphome-version: 2026.5.3
       groups: |
         [
-          {"name": "esp-web-tools", "files": "esp-web-tools/esp32.yaml\nesp-web-tools/esp8266.yaml"},
-          {"name": "esphome-web", "files": "esphome-web/esp32.factory.yaml"}
+          {"name": "esp-web-tools", "files": ["esp-web-tools/esp32.yaml", "esp-web-tools/esp8266.yaml"]},
+          {"name": "esphome-web", "files": ["esphome-web/esp32.factory.yaml"]}
         ]
 ```
 
@@ -77,8 +77,8 @@ combined group alongside standalone devices:
 ```yaml
       groups: |
         [
-          {"name": "esp32-generic", "files": "esp32-generic/esp32-generic.factory.yaml"},
-          {"name": "", "files": "gl-inet/gl-s10.factory.yaml\nwt32/wt32-eth01.factory.yaml"}
+          {"name": "esp32-generic", "files": ["esp32-generic/esp32-generic.factory.yaml"]},
+          {"name": "", "files": ["gl-inet/gl-s10.factory.yaml", "wt32/wt32-eth01.factory.yaml"]}
         ]
 ```
 


### PR DESCRIPTION
Repositories that publish several combined manifests from one release — esphome/firmware builds both `esp-web-tools` and `esphome-web` — could not adopt the thin `build-to-draft-release.yml` caller. The wrapper never forwarded `build.yml`'s `combined-name`, so each config would get its own manifest instead of the combined one, breaking the `update.source` manifest URLs that existing devices poll for OTA.

## Grouped builds

Adds a `combined-name` passthrough for the single-group case, and a `groups` input (JSON array of `{name, files}`) that publishes several combined manifests from one call, as a matrix over the inner `build.yml`. One group may use an empty name to publish its files as one manifest each, for repositories shipping a combined group alongside standalone devices.

Grouping is expressed in a single call rather than one call per group. Removing the draft's ASSETS_PENDING warning is a claim that the whole release is built, and only one job can make it: split across a call per group, whichever finished first would strip the warning while the others were still compiling, inviting a maintainer to publish a release missing a group. A single call also keeps a single upload job — `upload-to-gh-release.yml` takes every artifact in the run, so two calls in one workflow would upload each other's artifacts and race on identical asset names.

Per-group `files` is required and is not auto-discovered: discovery globs `*.factory.yaml` across the whole repository, so one group would sweep up another group's configs. `ci-draft-release.yml` gains a two-group smoke test asserting each group's manifest combines exactly its own builds.

## Draft asset cleanup moves to the drafter

`build-to-draft-release.yml` no longer cleans the draft's assets; it only adds them. `draft-calver-release.yml` now empties the draft immediately after release-drafter re-applies the release notes, and with them the ASSETS_PENDING warning.

That is the only point where deleting every asset is unambiguous: no build is in flight — the build workflows trigger on `workflow_run` of this workflow completing — so anything still attached is from an earlier build of the same draft. A clean running alongside the builds cannot tell a stale asset from one another build has just uploaded, which is what would otherwise force every repository into a single build+upload call per release. It also stops the draft advertising the previous build's assets for the whole compile window while claiming they are pending, and it cleans by the release id release-drafter reports rather than searching for "the first draft".

The clean's previous rationale (renamed files when the version bumps from .1 to .2) does not hold: release assets carry no version (`xiao-ir-mate.manifest.json`, `esp-web-tools-example-esp32.ota.bin`), and `upload-to-gh-release.yml` already replaces any same-named asset. It is a rare-event GC for renamed or removed devices.

This means a repository must use **both** halves of the pipeline: one whose Release Drafter workflow does not call `draft-calver-release.yml` never empties its draft.

## Backwards compatibility

Callers passing neither input resolve to a single unnamed group and still publish one manifest per file, with cleaning still happening (now via the drafter) and the build job still displaying as `Build Firmware`, so required status checks are unaffected. The permissions callers must grant are unchanged.

## Follow-ups

- A new release/tag is needed before consumers can pin to this; they currently pin `@9f6577fd37b5cf773ab1b9be929714a0dcd15661  # 2026.7.0`.
- Consumers should move their `draft-calver-release.yml` and `build-to-draft-release.yml` pins together; skew silently disables cleaning.
- esphome/firmware#361 can then drop its inline `build.yml` for a `groups` caller.
