### PR TITLE
Add reusable stale workflow measuring real activity

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -122,14 +122,16 @@ jobs:
                 per_page: 100,
               });
               const isRealUser = u => u?.type === 'User' && !IGNORED_USERS.has(u.login);
-              if (comments.some(c => isRealUser(c.user) && new Date(c.created_at) > since)) {
+              if (comments.some(c => isRealUser(c.user) && new Date(c.created_at) >= since)) {
                 return true;
               }
 
               if ('pull_request' in item) {
-                // Isolated so a commit lookup failure (e.g. an unreachable
-                // fork head) falls through to the review check instead of
-                // skipping the whole item
+                // The head SHA of a fork PR is reachable through the base
+                // repository (GitHub keeps refs/pull/N/head there), so the
+                // base-repo commit API is correct for fork PRs too. Isolated
+                // so an unexpected lookup failure falls through to the review
+                // check instead of skipping the whole item
                 try {
                   const {data: pull} = await github.rest.pulls.get({
                     owner: context.repo.owner,
@@ -142,7 +144,7 @@ jobs:
                     ref: pull.head.sha,
                   });
                   const lastCommitDate = head.commit?.committer?.date ?? head.commit?.author?.date;
-                  if (lastCommitDate && new Date(lastCommitDate) > since) {
+                  if (lastCommitDate && new Date(lastCommitDate) >= since) {
                     return true;
                   }
                 } catch (e) {
@@ -155,7 +157,7 @@ jobs:
                   pull_number: item.number,
                   per_page: 100,
                 });
-                if (reviews.some(r => isRealUser(r.user) && r.submitted_at && new Date(r.submitted_at) > since)) {
+                if (reviews.some(r => isRealUser(r.user) && r.submitted_at && new Date(r.submitted_at) >= since)) {
                   return true;
                 }
               }

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -70,6 +70,7 @@ on:
         default: false
 
 permissions:
+  contents: read        # repos.getCommit for the PR head commit date
   issues: write
   pull-requests: write
 

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -200,12 +200,14 @@ jobs:
                 if (labels.includes(STALE_LABEL)) {
                   // Already stale: real activity unmarks, silence closes
                   const labeledAt = await staleLabelDate(item);
-                  if (!labeledAt) continue;
+                  if (!labeledAt) {
+                    console.warn(`No ${STALE_LABEL} labeling event found for #${item.number}; skipping`);
+                    continue;
+                  }
 
                   if (await hasRealActivitySince(item, labeledAt)) {
                     const kind = isPr ? 'PR' : 'issue';
                     console.log(`Unmarking ${kind} #${item.number}: real activity since it was marked stale`);
-                    unmarked++;
                     if (!DRY_RUN) {
                       await github.rest.issues.removeLabel({
                         owner: context.repo.owner,
@@ -214,11 +216,11 @@ jobs:
                         name: STALE_LABEL,
                       });
                     }
+                    unmarked++;
                   } else if (labeledAt < closeCutoff) {
                     const kind = isPr ? 'PR' : 'issue';
                     console.log(`Closing ${kind} #${item.number}: ` +
                       `no real activity since stale on ${labeledAt.toISOString()}`);
-                    closed++;
                     if (!DRY_RUN) {
                       const update = {
                         owner: context.repo.owner,
@@ -232,6 +234,7 @@ jobs:
                       }
                       await github.rest.issues.update(update);
                     }
+                    closed++;
                   }
                   continue;
                 }
@@ -245,21 +248,24 @@ jobs:
                 const kind = isPr ? 'PR' : 'issue';
                 console.log(`Marking ${kind} #${item.number} as stale: ` +
                   `no real activity since ${staleCutoff.toISOString()} (updated_at ${item.updated_at})`);
-                marked++;
                 if (!DRY_RUN) {
-                  await github.rest.issues.addLabels({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    issue_number: item.number,
-                    labels: [STALE_LABEL],
-                  });
+                  // Comment before labeling: if the comment fails the item is
+                  // retried next run, instead of a labeled-but-unwarned item
+                  // being closed later without explanation
                   await github.rest.issues.createComment({
                     owner: context.repo.owner,
                     repo: context.repo.repo,
                     issue_number: item.number,
                     body: isPr ? STALE_PR_MESSAGE : STALE_ISSUE_MESSAGE,
                   });
+                  await github.rest.issues.addLabels({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: item.number,
+                    labels: [STALE_LABEL],
+                  });
                 }
+                marked++;
               } catch (e) {
                 console.error(`Failed to process #${item.number}: ${e instanceof Error ? e.message : e}`);
               }

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -55,6 +55,14 @@ on:
 
           This issue has now been marked as stale and will be closed if no
           further activity occurs. Thank you for your contributions.
+      ignored-users:
+        description: >
+          Comma-separated logins whose comments and reviews do not count as
+          activity — for machine accounts of type User, which the automatic
+          bot filter cannot detect (App bots are always ignored)
+        required: false
+        type: string
+        default: ''
       dry-run:
         description: Log what would happen without labeling, commenting or closing
         required: false
@@ -83,6 +91,7 @@ jobs:
             const EXEMPT_LABEL = "${{ inputs.exempt-label }}";
             const STALE_PR_MESSAGE = process.env.STALE_PR_MESSAGE;
             const STALE_ISSUE_MESSAGE = process.env.STALE_ISSUE_MESSAGE;
+            const IGNORED_USERS = new Set("${{ inputs.ignored-users }}".split(',').map(s => s.trim()).filter(Boolean));
             const DRY_RUN = ${{ inputs.dry-run }};
 
             const now = new Date();
@@ -111,7 +120,8 @@ jobs:
                 since: since.toISOString(),
                 per_page: 100,
               });
-              if (comments.some(c => c.user?.type === 'User' && new Date(c.created_at) > since)) {
+              const isRealUser = u => u?.type === 'User' && !IGNORED_USERS.has(u.login);
+              if (comments.some(c => isRealUser(c.user) && new Date(c.created_at) > since)) {
                 return true;
               }
 
@@ -144,7 +154,7 @@ jobs:
                   pull_number: item.number,
                   per_page: 100,
                 });
-                if (reviews.some(r => r.user?.type === 'User' && r.submitted_at && new Date(r.submitted_at) > since)) {
+                if (reviews.some(r => isRealUser(r.user) && r.submitted_at && new Date(r.submitted_at) > since)) {
                   return true;
                 }
               }

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -116,19 +116,26 @@ jobs:
               }
 
               if ('pull_request' in item) {
-                const {data: pull} = await github.rest.pulls.get({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  pull_number: item.number,
-                });
-                const {data: head} = await github.rest.repos.getCommit({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  ref: pull.head.sha,
-                });
-                const lastCommitDate = head.commit?.committer?.date ?? head.commit?.author?.date;
-                if (lastCommitDate && new Date(lastCommitDate) > since) {
-                  return true;
+                // Isolated so a commit lookup failure (e.g. an unreachable
+                // fork head) falls through to the review check instead of
+                // skipping the whole item
+                try {
+                  const {data: pull} = await github.rest.pulls.get({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    pull_number: item.number,
+                  });
+                  const {data: head} = await github.rest.repos.getCommit({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    ref: pull.head.sha,
+                  });
+                  const lastCommitDate = head.commit?.committer?.date ?? head.commit?.author?.date;
+                  if (lastCommitDate && new Date(lastCommitDate) > since) {
+                    return true;
+                  }
+                } catch (e) {
+                  console.error(`Commit check failed for #${item.number}: ${e instanceof Error ? e.message : e}`);
                 }
 
                 const reviews = await github.paginate(github.rest.pulls.listReviews, {
@@ -241,7 +248,7 @@ jobs:
                   });
                 }
               } catch (e) {
-                console.error(`Failed to process #${item.number}: ${e.message}`);
+                console.error(`Failed to process #${item.number}: ${e instanceof Error ? e.message : e}`);
               }
             }
 

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -73,7 +73,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Process stale issues and PRs
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
         with:
           script: |
             const DAYS_BEFORE_STALE = ${{ inputs.days-before-stale }};
@@ -179,7 +179,8 @@ jobs:
                   if (!labeledAt) continue;
 
                   if (await hasRealActivitySince(item, labeledAt)) {
-                    console.log(`Unmarking ${isPr ? 'PR' : 'issue'} #${item.number}: real activity since it was marked stale`);
+                    const kind = isPr ? 'PR' : 'issue';
+                    console.log(`Unmarking ${kind} #${item.number}: real activity since it was marked stale`);
                     unmarked++;
                     if (!DRY_RUN) {
                       await github.rest.issues.removeLabel({
@@ -190,7 +191,9 @@ jobs:
                       });
                     }
                   } else if (labeledAt < closeCutoff) {
-                    console.log(`Closing ${isPr ? 'PR' : 'issue'} #${item.number}: no real activity since it was marked stale on ${labeledAt.toISOString()}`);
+                    const kind = isPr ? 'PR' : 'issue';
+                    console.log(`Closing ${kind} #${item.number}: ` +
+                      `no real activity since stale on ${labeledAt.toISOString()}`);
                     closed++;
                     if (!DRY_RUN) {
                       const update = {
@@ -215,7 +218,9 @@ jobs:
                 if (updatedAt >= staleCutoff && createdAt >= staleCutoff) continue;
                 if (updatedAt >= staleCutoff && await hasRealActivitySince(item, staleCutoff)) continue;
 
-                console.log(`Marking ${isPr ? 'PR' : 'issue'} #${item.number} as stale: no real activity since ${staleCutoff.toISOString()} (updated_at ${item.updated_at})`);
+                const kind = isPr ? 'PR' : 'issue';
+                console.log(`Marking ${kind} #${item.number} as stale: ` +
+                  `no real activity since ${staleCutoff.toISOString()} (updated_at ${item.updated_at})`);
                 marked++;
                 if (!DRY_RUN) {
                   await github.rest.issues.addLabels({

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,242 @@
+---
+name: Stale issues and PRs
+
+on:
+  workflow_call:
+    inputs:
+      days-before-stale:
+        description: Days without real activity before an item is marked stale
+        required: false
+        type: number
+        default: 90
+      days-before-close:
+        description: Days after the stale label before an item is closed
+        required: false
+        type: number
+        default: 7
+      stale-label:
+        description: Label used to mark stale items
+        required: false
+        type: string
+        default: stale
+      exempt-label:
+        description: Items with this label are never marked or closed
+        required: false
+        type: string
+        default: not-stale
+      stale-pr-message:
+        description: Comment posted when a PR is marked stale
+        required: false
+        type: string
+        default: >
+          There hasn't been any activity on this pull request recently. This
+          pull request has been automatically marked as stale because of that
+          and will be closed if no further activity occurs within 7 days.
+
+          If you are the author of this PR, please leave a comment if you want
+          to keep it open. Also, please rebase your PR onto the latest dev
+          branch to ensure that it's up to date with the latest changes.
+
+          Thank you for your contribution!
+      stale-issue-message:
+        description: Comment posted when an issue is marked stale
+        required: false
+        type: string
+        default: >
+          There hasn't been any activity on this issue recently. Due to the
+          high number of incoming GitHub notifications, we have to clean some
+          of the old issues, as many of them have already been resolved with
+          the latest updates.
+
+          Please make sure to update to the latest version and check if that
+          solves the issue. Let us know if that works for you by adding a
+          comment 👍
+
+          This issue has now been marked as stale and will be closed if no
+          further activity occurs. Thank you for your contributions.
+      dry-run:
+        description: Log what would happen without labeling, commenting or closing
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: stale
+  cancel-in-progress: false
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Process stale issues and PRs
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const DAYS_BEFORE_STALE = ${{ inputs.days-before-stale }};
+            const DAYS_BEFORE_CLOSE = ${{ inputs.days-before-close }};
+            const STALE_LABEL = "${{ inputs.stale-label }}";
+            const EXEMPT_LABEL = "${{ inputs.exempt-label }}";
+            const STALE_PR_MESSAGE = process.env.STALE_PR_MESSAGE;
+            const STALE_ISSUE_MESSAGE = process.env.STALE_ISSUE_MESSAGE;
+            const DRY_RUN = ${{ inputs.dry-run }};
+
+            const now = new Date();
+            const staleCutoff = new Date(now.getTime() - DAYS_BEFORE_STALE * 24 * 60 * 60 * 1000);
+            const closeCutoff = new Date(now.getTime() - DAYS_BEFORE_CLOSE * 24 * 60 * 60 * 1000);
+
+            console.log(`Will mark items without real activity since: ${staleCutoff.toISOString()}`);
+            console.log(`Will close items marked stale before: ${closeCutoff.toISOString()}`);
+
+            // The GitHub updated_at timestamp moves on events that are not
+            // real activity: bots editing their comments in place, label
+            // changes and similar housekeeping. Real activity is therefore
+            // measured directly: comments *created* by users, and for PRs
+            // also commits and review submissions. Since every kind of real
+            // activity also bumps updated_at, the timestamp is an upper
+            // bound: an item whose updated_at is old is conclusively
+            // inactive, and only apparently-fresh items need verification.
+            async function hasRealActivitySince(item, since) {
+              // Note: the `since` filter of listComments matches the comment
+              // updated_at, so an edited old comment reappears here; compare
+              // created_at to only count genuinely new comments.
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: item.number,
+                since: since.toISOString(),
+                per_page: 100,
+              });
+              if (comments.some(c => c.user?.type === 'User' && new Date(c.created_at) > since)) {
+                return true;
+              }
+
+              if ('pull_request' in item) {
+                const commits = await github.paginate(github.rest.pulls.listCommits, {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: item.number,
+                  per_page: 100,
+                });
+                const last = commits[commits.length - 1];
+                const lastCommitDate = last?.commit?.committer?.date ?? last?.commit?.author?.date;
+                if (lastCommitDate && new Date(lastCommitDate) > since) {
+                  return true;
+                }
+
+                const reviews = await github.paginate(github.rest.pulls.listReviews, {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: item.number,
+                  per_page: 100,
+                });
+                if (reviews.some(r => r.user?.type === 'User' && r.submitted_at && new Date(r.submitted_at) > since)) {
+                  return true;
+                }
+              }
+
+              return false;
+            }
+
+            async function staleLabelDate(item) {
+              const events = await github.paginate(github.rest.issues.listEvents, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: item.number,
+                per_page: 100,
+              });
+              const labelings = events.filter(e => e.event === 'labeled' && e.label?.name === STALE_LABEL);
+              const last = labelings[labelings.length - 1];
+              return last ? new Date(last.created_at) : null;
+            }
+
+            const openItems = await github.paginate(github.rest.issues.listForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              per_page: 100,
+            });
+            console.log(`Processing ${openItems.length} open items`);
+
+            let marked = 0, unmarked = 0, closed = 0;
+
+            for (const item of openItems) {
+              if (item.locked) continue;
+              const labels = item.labels.map(l => l.name);
+              if (labels.includes(EXEMPT_LABEL)) continue;
+
+              const isPr = 'pull_request' in item;
+              const updatedAt = new Date(item.updated_at);
+              const createdAt = new Date(item.created_at);
+
+              try {
+                if (labels.includes(STALE_LABEL)) {
+                  // Already stale: real activity unmarks, silence closes
+                  const labeledAt = await staleLabelDate(item);
+                  if (!labeledAt) continue;
+
+                  if (await hasRealActivitySince(item, labeledAt)) {
+                    console.log(`Unmarking ${isPr ? 'PR' : 'issue'} #${item.number}: real activity since it was marked stale`);
+                    unmarked++;
+                    if (!DRY_RUN) {
+                      await github.rest.issues.removeLabel({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        issue_number: item.number,
+                        name: STALE_LABEL,
+                      });
+                    }
+                  } else if (labeledAt < closeCutoff) {
+                    console.log(`Closing ${isPr ? 'PR' : 'issue'} #${item.number}: no real activity since it was marked stale on ${labeledAt.toISOString()}`);
+                    closed++;
+                    if (!DRY_RUN) {
+                      const update = {
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        issue_number: item.number,
+                        state: 'closed',
+                      };
+                      // Issues support a close reason; PRs do not
+                      if (!isPr) {
+                        update.state_reason = 'not_planned';
+                      }
+                      await github.rest.issues.update(update);
+                    }
+                  }
+                  continue;
+                }
+
+                // Not stale yet. An old updated_at is conclusive; a fresh one
+                // may be a phantom update and needs verification, but only
+                // for items old enough to possibly be inactive.
+                if (updatedAt >= staleCutoff && createdAt >= staleCutoff) continue;
+                if (updatedAt >= staleCutoff && await hasRealActivitySince(item, staleCutoff)) continue;
+
+                console.log(`Marking ${isPr ? 'PR' : 'issue'} #${item.number} as stale: no real activity since ${staleCutoff.toISOString()} (updated_at ${item.updated_at})`);
+                marked++;
+                if (!DRY_RUN) {
+                  await github.rest.issues.addLabels({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: item.number,
+                    labels: [STALE_LABEL],
+                  });
+                  await github.rest.issues.createComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: item.number,
+                    body: isPr ? STALE_PR_MESSAGE : STALE_ISSUE_MESSAGE,
+                  });
+                }
+              } catch (e) {
+                console.error(`Failed to process #${item.number}: ${e.message}`);
+              }
+            }
+
+            console.log(`Done${DRY_RUN ? ' (dry run)' : ''}: ${marked} marked, ${unmarked} unmarked, ${closed} closed`);
+        env:
+          STALE_PR_MESSAGE: ${{ inputs.stale-pr-message }}
+          STALE_ISSUE_MESSAGE: ${{ inputs.stale-issue-message }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -31,11 +31,12 @@ on:
         default: >
           There hasn't been any activity on this pull request recently. This
           pull request has been automatically marked as stale because of that
-          and will be closed if no further activity occurs within 7 days.
+          and will be closed if no further activity occurs.
 
           If you are the author of this PR, please leave a comment if you want
-          to keep it open. Also, please rebase your PR onto the latest dev
-          branch to ensure that it's up to date with the latest changes.
+          to keep it open. Also, please rebase your PR onto the latest
+          development branch to ensure that it's up to date with the latest
+          changes.
 
           Thank you for your contribution!
       stale-issue-message:
@@ -115,14 +116,17 @@ jobs:
               }
 
               if ('pull_request' in item) {
-                const commits = await github.paginate(github.rest.pulls.listCommits, {
+                const {data: pull} = await github.rest.pulls.get({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   pull_number: item.number,
-                  per_page: 100,
                 });
-                const last = commits[commits.length - 1];
-                const lastCommitDate = last?.commit?.committer?.date ?? last?.commit?.author?.date;
+                const {data: head} = await github.rest.repos.getCommit({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  ref: pull.head.sha,
+                });
+                const lastCommitDate = head.commit?.committer?.date ?? head.commit?.author?.date;
                 if (lastCommitDate && new Date(lastCommitDate) > since) {
                   return true;
                 }


### PR DESCRIPTION
## What

A reusable stale workflow in the same shape as the shared lock workflow: `workflow_call` + inline `github-script`, no third-party action. Intended to replace `actions/stale` in esphome/esphome (thin caller PR to follow once this merges).

## Why

`actions/stale` measures staleness from the GitHub `updated_at` timestamp, which also moves on events that are not real activity — most importantly **bots editing their own comments in place**. On esphome/esphome, codecov edits its coverage comments on old PRs for months after posting; each edit invisibly bumps the PR's `updated_at` (no timeline event, no notification).

Evidence, using esphome/esphome#10182 as the case study:
- The stale run logs show the bot processes all 734 open items using 37 of 400 operations and correctly concludes "not stale" from `updated_at` values of 2026-04-08 and 2026-06-04 — dates on which the PR has **no visible activity of any kind**.
- GraphQL `userContentEdits` on the PR's codecov comment shows edits at exactly `2026-04-08T02:44:31Z` and `2026-06-04T07:58:53Z` — matching the phantom timestamps to the second. During March–April the comment was edited a dozen times in two weeks.
- The same mechanism explains the mark→next-day-unmark cycles observed on other PRs (an edit landing inside the 7-day close window rescues the item).

`actions/stale` has no middle-ground option: it either trusts `updated_at` or (with `ignore-updates`) uses the creation date only, which would stale-spam every actively developed long-lived PR. The upstream request for an activity-based mode (actions/stale#1114) has been open since 2023.

## How

Real activity is measured directly:
- comments **created** by users — bot comments don't count, and comment *edits* are ignored by comparing `created_at` (the `listComments` `since` filter matches the comment `updated_at`, so edited old comments reappear in it — this subtlety is load-bearing);
- for PRs additionally: commits and human review submissions.

Since every kind of real activity also bumps `updated_at`, the timestamp is an upper bound: an old `updated_at` is conclusively inactive, and the extra API lookups only run for items the timestamp alone would spare.

Closing an issue uses `state_reason: not_planned`, matching the `actions/stale` default we run today. A `dry-run` input logs decisions without labeling/commenting/closing, for safe rollout.

## Simulated against esphome/esphome (read-only)

Of 730 open items: 8 exempt (`not-stale`), 416 fresh, **227 verified genuinely active** by the lazy check, and **61 would be marked stale** — 58 PRs and 3 issues, a split that independently corroborates codecov as the phantom source (it only comments on PRs). 482 verification API calls total, against a 1000/hour budget.

Note for rollout: nothing currently carries the stale label, so the first live run would post ~61 stale comments at once. Suggested sequence: merge, point esphome at it with `dry-run: true` for a couple of days, review the logs, then flip.