### PR TITLE
Pass --allow-escape-sequences when downloading release assets

### DIFF
--- a/.github/workflows/publish-draft-release.yml
+++ b/.github/workflows/publish-draft-release.yml
@@ -114,9 +114,12 @@ jobs:
             echo "::error::No *.manifest.json assets found on draft release"
             exit 1
           fi
+          # --allow-escape-sequences (gh >= 2.97.0): gh refuses to write a
+          # response body containing terminal escape bytes, which a manifest
+          # carrying an escape byte in the embedded release body would trip.
           while IFS=$'\t' read -r asset_id asset_name; do
             echo "Downloading ${asset_name}"
-            gh api -H "Accept: application/octet-stream" \
+            gh api --allow-escape-sequences -H "Accept: application/octet-stream" \
               "repos/${GH_REPO}/releases/assets/${asset_id}" \
               > "assets/${asset_name}"
           done <<< "${assets}"

--- a/.github/workflows/publish-firmware-to-r2.yml
+++ b/.github/workflows/publish-firmware-to-r2.yml
@@ -171,7 +171,10 @@ jobs:
               return 1
             fi
             echo "Downloading ${name}"
-            gh api -H "Accept: application/octet-stream" \
+            # --allow-escape-sequences (gh >= 2.97.0): gh refuses to write a
+            # response body containing terminal escape bytes. Firmware images
+            # are arbitrary binary, so they trip that guard at random.
+            gh api --allow-escape-sequences -H "Accept: application/octet-stream" \
               "repos/${GH_REPO}/releases/assets/${asset_id}" > "${target}/${name}"
           }
 


### PR DESCRIPTION
gh 2.97.0 added a security guard that refuses to write a response body containing terminal escape bytes, offering `--allow-escape-sequences` as the opt-out. Firmware images are arbitrary binary, so whether any given one contains such a byte sequence is luck. That made asset downloads fail nondeterministically: [this bluetooth-proxies run](https://github.com/esphome/bluetooth-proxies/actions/runs/31760195480) lost 4 of 9 "Prepare <device> artifact" jobs, which in turn blocked `Upload to R2` and both promote jobs, while the other 5 devices passed on identical code.

Both sites that stream an asset body through `gh api` now pass the flag: the firmware download in `publish-firmware-to-r2.yml` (the actual failure) and the manifest download in `publish-draft-release.yml`. Manifests are JSON and rarely trip the guard, but a release body embedded in one could carry an escape byte, so it gets the same treatment.

The asset *listing* calls still use plain `gh api`. They return JSON that gh is happy to write, and `--jq` is convenient there.

Verified against `gl-s10-esp32.factory.bin`, one of the assets that actually failed: without the flag `gh api` exits 1 having written 0 bytes; with it, it exits 0 and produces a file byte-identical (sha256 `06d1d08d…`) to the same asset fetched over plain curl. So the flag suppresses the check outright rather than rewriting the payload, and binary passes through intact.

One deployment note: the guard and the flag both shipped in gh 2.97.0, so any runner new enough to reject a download is new enough to accept the flag. The reverse is the only risk, since gh 2.96 would reject the flag as unknown. `actions/runner-images` still lists 2.96.0 in its `ubuntu-latest` README, but the failing run above clearly hit the 2.97 guard, so that README is lagging the rollout rather than describing it.

Consumers pinning this workflow will need their pin bumped once this is released.