### PR TITLE
Download release assets with curl instead of gh api

### DIFF
--- a/.github/workflows/publish-draft-release.yml
+++ b/.github/workflows/publish-draft-release.yml
@@ -114,14 +114,21 @@ jobs:
             echo "::error::No *.manifest.json assets found on draft release"
             exit 1
           fi
-          # --allow-escape-sequences (gh >= 2.97.0): gh refuses to write a
-          # response body containing terminal escape bytes, which a manifest
-          # carrying an escape byte in the embedded release body would trip.
+          # curl, not `gh api`: gh refuses to write a response body holding
+          # terminal escape bytes (a manifest embedding one in the release
+          # body trips that), and its --allow-escape-sequences opt-out needs
+          # gh >= 2.97.0, which the runner images do not all ship.
+          # -f so an HTTP error fails the step instead of writing the error
+          # body as a manifest; -L because the asset endpoint redirects to
+          # signed storage (which rejects a forwarded Authorization header,
+          # so no --location-trusted).
           while IFS=$'\t' read -r asset_id asset_name; do
             echo "Downloading ${asset_name}"
-            gh api --allow-escape-sequences -H "Accept: application/octet-stream" \
-              "repos/${GH_REPO}/releases/assets/${asset_id}" \
-              > "assets/${asset_name}"
+            curl -fsSL \
+              -H "Authorization: Bearer ${GH_TOKEN}" \
+              -H "Accept: application/octet-stream" \
+              "https://api.github.com/repos/${GH_REPO}/releases/assets/${asset_id}" \
+              -o "assets/${asset_name}"
           done <<< "${assets}"
 
       - name: Patch manifests with current release body

--- a/.github/workflows/publish-firmware-to-r2.yml
+++ b/.github/workflows/publish-firmware-to-r2.yml
@@ -171,11 +171,18 @@ jobs:
               return 1
             fi
             echo "Downloading ${name}"
-            # --allow-escape-sequences (gh >= 2.97.0): gh refuses to write a
-            # response body containing terminal escape bytes. Firmware images
-            # are arbitrary binary, so they trip that guard at random.
-            gh api --allow-escape-sequences -H "Accept: application/octet-stream" \
-              "repos/${GH_REPO}/releases/assets/${asset_id}" > "${target}/${name}"
+            # curl, not `gh api`: gh refuses to write a response body holding
+            # terminal escape bytes, and its --allow-escape-sequences opt-out
+            # needs gh >= 2.97.0, which the runner images do not all ship.
+            # -f so an HTTP error fails the step instead of writing the error
+            # body as firmware; -L because the asset endpoint redirects to
+            # signed storage (which rejects a forwarded Authorization header,
+            # so no --location-trusted).
+            curl -fsSL \
+              -H "Authorization: Bearer ${GH_TOKEN}" \
+              -H "Accept: application/octet-stream" \
+              "https://api.github.com/repos/${GH_REPO}/releases/assets/${asset_id}" \
+              -o "${target}/${name}"
           }
 
           download "${DEVICE}.manifest.json"


### PR DESCRIPTION
`gh api` refuses to write a response body containing terminal escape bytes. The `--allow-escape-sequences` opt-out added in #178 works around that, but it only exists in gh >= 2.97.0, and the `ubuntu-latest` pool serves mixed image versions while a new image rolls out. That makes it a per-job coin flip: on the esphome/bluetooth-proxies 26.8.2 release, 5 of 8 matrix devices passed and 3 (m5stack-atom-s3, wt32-eth01, lilygo-t-eth-poe) failed immediately with `unknown flag: --allow-escape-sequences` ([run](https://github.com/esphome/bluetooth-proxies/actions/runs/31767723642)). There is no way to pin a hosted runner image version, so this cannot be waited out.

This swaps the asset-body downloads to curl, which has no version floor and no escape-sequence guard. Two flags are load-bearing: `-f` so an HTTP error fails the step under `set -euo pipefail` instead of silently writing the error body out as a valid-looking asset, and `-L` because the asset endpoint redirects to signed object storage. curl deliberately drops the `Authorization` header on the cross-host redirect, which is required here since the storage backend rejects a forwarded one, so no `--location-trusted`.

Both workflows using the pattern are covered: `publish-firmware-to-r2.yml` (firmware binaries, the one that failed) and `publish-draft-release.yml` (manifest downloads, same version floor and the same latent failure). The JSON-returning `gh api` calls are unaffected and stay as they are - gh is still the right tool for `--paginate` and `--jq`, just not for moving bytes. The remaining `releases/assets/<id>` calls elsewhere are DELETEs and uploads, which send binary in rather than writing a response body out, so the guard does not apply to them.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)