### PR TITLE
Measure stale unmarking from the stale window, not just the label date

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -228,7 +228,11 @@ jobs:
                     continue;
                   }
 
-                  if (await hasRealActivitySince(item, labeledAt)) {
+                  // Measure from whichever is later, so activity that is
+                  // itself older than the stale window cannot clear the label
+                  // on an item that was marked long ago.
+                  const since = labeledAt > staleCutoff ? labeledAt : staleCutoff;
+                  if (await hasRealActivitySince(item, since)) {
                     const kind = isPr ? 'PR' : 'issue';
                     console.log(`Unmarking ${kind} #${item.number}: real activity since it was marked stale`);
                     if (!DRY_RUN) {


### PR DESCRIPTION
The unmark check asks whether there has been activity *since the stale label was applied*, while the marking check asks whether there has been activity *in the last 90 days*. Those are different questions, and once the label is older than the window both can be true at once — so an item is unmarked one night and marked again the next, posting a fresh stale comment every time.

esphome/esphome#10867 is a worked example:

```
2025-12-29 00:50  labeled stale       github-actions[bot]
2026-01-05 00:50  closed              github-actions[bot]
2026-01-05 01:05  comment "duh."      ireun
2026-01-13 00:48  locked              github-actions[bot]
2026-08-13 08:50  reopened, unlocked  ssieb
2026-08-14 00:52  unlabeled stale     esphome[bot]
2026-08-15 00:50  labeled stale       esphome[bot]
```

The reporter replied 16 minutes after the auto-close, and the issue was locked a week later. Locked items are skipped, so it sat untouched for seven months with the December label still attached. Reopening it put it back in the loop: that January comment was activity since the label, so the label came off on the 14th, and on the 15th the marking check found nothing inside 90 days and put it straight back on.

Measuring from whichever of the label date and the stale cutoff is later fixes it — activity that is itself outside the stale window can no longer clear the label. Items labelled in the normal course are unaffected, since a label applied days ago is always newer than the cutoff.

One consequence worth knowing: an item that is reopened while still carrying an old stale label now reaches the close branch on the next run rather than flip-flopping, and that branch posts no comment before closing. `not-stale` is the escape hatch, and removing the label when reopening also works. Counting a reopen as activity in its own right would handle that case properly, but it needs `listEvents` plumbed into `hasRealActivitySince` and is left for a follow-up.
